### PR TITLE
docs: update cookbook repo reference (cubrid-cookbook-python)

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ stmt = insert(users).values(name="Alice").on_duplicate_key_update(name="Alice Up
 ## Related Projects
 
 - [pycubrid](https://github.com/cubrid-labs/pycubrid) — Pure Python DB-API 2.0 driver for CUBRID
-- [cubrid-python-cookbook](https://github.com/cubrid-labs/cubrid-python-cookbook) — Production-ready Python examples for CUBRID
+- [cubrid-cookbook-python](https://github.com/cubrid-labs/cubrid-cookbook-python) — Production-ready Python examples for CUBRID
 
 ## Roadmap
 


### PR DESCRIPTION
## Summary
- Update Related Projects link: `cubrid-python-cookbook` → `cubrid-cookbook-python`
- Repository was renamed to align with `cubrid-cookbook-*` namespace for multi-language expansion