### PR TITLE
feat: add async dialect support (create_async_engine)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Async dialect** via `cubrid+aiopycubrid://` URL scheme
+  - `PyCubridAsyncDialect` (`is_async=True`) using SQLAlchemy's `AsyncAdapt_dbapi_*` base classes
+  - `AsyncAdapt_pycubrid_dbapi` wraps `pycubrid.aio` module
+  - `AsyncAdapt_pycubrid_connection` bridges autocommit via greenlet `await_only`
+  - `AsyncAdapt_pycubrid_cursor` with full async cursor adaptation
+  - `cubrid.aiopycubrid` entry point auto-discovered by SQLAlchemy
+- 17 new async dialect offline tests (`test/test_aio_pycubrid_dialect.py`)
+
 ## [1.0.0] - 2026-04-11
 
 ### Stability Guarantee

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ production-ready SQLAlchemy dialect that supports the modern 2.0–2.1 API.
 - Tested against **4 CUBRID versions** (10.2, 11.0, 11.2, 11.4) across **Python 3.10 -- 3.14**
 - CUBRID-specific DML constructs: `ON DUPLICATE KEY UPDATE`, `MERGE`, `REPLACE INTO`
 - Alembic migration support out of the box
-- **Two driver options** — C-extension (`cubrid://`) or pure Python (`cubrid+pycubrid://`)
+- **Three driver options** — C-extension (`cubrid://`), pure Python (`cubrid+pycubrid://`), or async pure Python (`cubrid+aiopycubrid://`)
 
 ## Architecture
 
@@ -39,8 +39,10 @@ flowchart TD
     sa --> dialect["CubridDialect"]
     dialect --> pycubrid["pycubrid driver"]
     dialect --> cext["CUBRIDdb driver"]
+    dialect --> aio["pycubrid.aio async driver"]
     pycubrid --> server["CUBRID Server"]
     cext --> server
+    aio --> server
 ```
 
 ```mermaid
@@ -114,6 +116,19 @@ with Session(engine) as session:
     session.commit()
 ```
 
+### Async
+
+```python
+from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
+from sqlalchemy import text
+
+engine = create_async_engine("cubrid+aiopycubrid://dba:password@localhost:33000/demodb")
+
+async with AsyncSession(engine) as session:
+    result = await session.execute(text("SELECT 1"))
+    print(result.scalar())
+```
+
 ## Features
 
 - Complete type system -- numeric, string, date/time, bit, LOB, and collection types
@@ -123,6 +138,7 @@ with Session(engine) as session:
 - Schema reflection -- tables, views, columns, PKs, FKs, indexes, unique constraints, comments
 - Alembic migrations via `CubridImpl` (auto-discovered entry point)
 - All 6 CUBRID isolation levels (dual-granularity: class-level + instance-level)
+- Async support — `create_async_engine("cubrid+aiopycubrid://...")` via pycubrid.aio
 
 ## Documentation
 
@@ -138,6 +154,7 @@ with Session(engine) as session:
 | [Development](docs/DEVELOPMENT.md) | Dev setup, testing, Docker, coverage, CI/CD |
 | [Driver Compatibility](docs/DRIVER_COMPAT.md) | CUBRID-Python driver versions and known issues |
 | [Troubleshooting](docs/TROUBLESHOOTING.md) | Common issues, error solutions, debugging techniques |
+| [Async Connection](docs/CONNECTION.md#async-connection) | Async engine setup with `cubrid+aiopycubrid://` |
 
 ## Compatibility Matrix
 
@@ -184,7 +201,11 @@ stmt = insert(users).values(name="Alice").on_duplicate_key_update(name="Alice Up
 
 ### What's the difference between `cubrid://` and `cubrid+pycubrid://`?
 
-`cubrid://` uses the C-extension driver (CUBRIDdb) which requires compilation. `cubrid+pycubrid://` uses the pure Python driver which installs with pip alone — no build tools needed.
+`cubrid://` uses the C-extension driver (CUBRIDdb) which requires compilation. `cubrid+pycubrid://` uses the pure Python driver which installs with pip alone — no build tools needed. `cubrid+aiopycubrid://` uses the async variant of the pure Python driver for use with `create_async_engine` and `AsyncSession`.
+
+### Does sqlalchemy-cubrid support async?
+
+Yes. Use `create_async_engine("cubrid+aiopycubrid://...")` with the pycubrid async driver. Requires `pycubrid>=1.1.0`. All Core and ORM features work with `AsyncSession`.
 
 
 ## Related Projects

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -27,3 +27,10 @@
 ## Compatibility
 
 Python 3.10+, SQLAlchemy 2.0–2.1, CUBRID 10.2–11.4
+
+## Completed
+
+### Async Dialect Support
+- `cubrid+aiopycubrid://` URL scheme via `PyCubridAsyncDialect`
+- Full `create_async_engine` / `AsyncSession` support
+- Requires pycubrid >= 1.1.0 with async module

--- a/docs/CONNECTION.md
+++ b/docs/CONNECTION.md
@@ -120,9 +120,25 @@ The dialect registers three SQLAlchemy entry points:
 | `cubrid://`          | CUBRIDdb    | Default C-extension driver           |
 | `cubrid+cubrid://`   | CUBRIDdb    | Explicit C-extension driver          |
 | `cubrid+pycubrid://` | pycubrid    | Pure Python driver (no C build)      |
+| `cubrid+aiopycubrid://` | pycubrid.aio | Async pure Python driver          |
 
 Use `cubrid://` for the C-extension driver (best performance), or `cubrid+pycubrid://` for the pure Python driver (easiest installation, no native build step).
 ---
+
+## Async Connection
+
+For async applications, use the `cubrid+aiopycubrid://` URL scheme with `create_async_engine`. Requires `pycubrid>=1.1.0`.
+
+```python
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlalchemy import text
+
+engine = create_async_engine("cubrid+aiopycubrid://dba@localhost:33000/testdb")
+
+async with engine.connect() as conn:
+    result = await conn.execute(text("SELECT 1"))
+    print(result.scalar())
+```
 
 ## How the Dialect Translates URLs
 
@@ -405,10 +421,13 @@ flowchart TD
     parse --> check{Driver name}
     check -->|cubrid or cubrid+cubrid| cext[Build CUBRID native DSN]
     check -->|cubrid+pycubrid| pykw[Build pycubrid kwargs]
+    check -->|cubrid+aiopycubrid| aio[Build pycubrid.aio kwargs]
     cext --> connect1[CUBRIDdb.connect(url, user, password)]
     pykw --> connect2[pycubrid.connect(host, port, database, user, password)]
+    aio --> connect3[pycubrid.aio.connect(...)]
     connect1 --> session[Dialect on_connect sets autocommit=False]
     connect2 --> session
+    connect3 --> session
 ```
 
 !!! warning "Use the correct dialect prefix"

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -92,6 +92,7 @@ graph TD
 [project.entry-points."sqlalchemy.dialects"]
 cubrid = "sqlalchemy_cubrid.dialect:CubridDialect"
 "cubrid.cubrid" = "sqlalchemy_cubrid.dialect:CubridDialect"
+"cubrid.aiopycubrid" = "sqlalchemy_cubrid.aio_pycubrid_dialect:PyCubridAsyncDialect"
 
 [project.entry-points."alembic.ddl"]
 cubrid = "sqlalchemy_cubrid.alembic_impl:CubridImpl"
@@ -192,6 +193,8 @@ class CubridDialect(default.DefaultDialect):
     max_identifier_length = 254
     default_paramstyle = "qmark"
 ```
+
+> **Async dialect**: `PyCubridAsyncDialect` subclasses the pycubrid dialect with `is_async = True` and wraps `pycubrid.aio` via `AsyncAdapt_pycubrid_dbapi`. Registered under the `cubrid.aiopycubrid` entry point for use with `create_async_engine("cubrid+aiopycubrid://...")`.
 
 #### Reflection Methods (All Implemented)
 
@@ -309,6 +312,7 @@ Limitations imposed by CUBRID itself (not the dialect):
 | `IS DISTINCT FROM` | ❌ | Not a CUBRID SQL operator |
 | `RELEASE SAVEPOINT` | ❌ | Dialect implements as no-op |
 | Check constraint reflection | ❌ | CUBRID parses but ignores CHECK |
+| Async DBAPI support | ✅ | Via pycubrid.aio async driver (`cubrid+aiopycubrid://`) |
 | Two-phase commit (XA) | ❌ | CUBRID has no distributed transaction support |
 | Server-side cursors | ❌ | CUBRID Python driver limitation |
 | Alembic ALTER COLUMN TYPE | ❌ | Use `batch_alter_table` workaround |
@@ -384,7 +388,7 @@ Limitations imposed by CUBRID itself (not the dialect):
 |---|---|---|---|
 | SQLAlchemy 2.1 compatibility | Track SA 2.1 breaking changes, update dialect accordingly | High | ⏳ SA 2.1 not released |
 | SQLAlchemy 2.2+ forward compat | Test and adjust for future SA releases | High | ⏳ Not released |
-| Async DBAPI support | If CUBRID Python driver adds async support, implement `create_async_engine` compatibility | Medium | ⏳ Driver has no async |
+| Async DBAPI support | If CUBRID Python driver adds async support, implement `create_async_engine` compatibility | Medium | ✅ Done |
 | Type annotation improvements | Add full `overload` signatures for `insert()`, `merge()` return types | Medium | ✅ Done |
 | `RETURNING` emulation | Investigate TRIGGER-based or `LAST_INSERT_ID` workaround for single-row returning | Low | ⏳ Not started |
 

--- a/docs/SUPPORT_MATRIX.md
+++ b/docs/SUPPORT_MATRIX.md
@@ -54,6 +54,7 @@ These will be migrated to public APIs when SA 2.2 is released.
 |---|---|---|---|
 | CUBRID-Python (CCI) | `pip install "sqlalchemy-cubrid[cubrid]"` | `cubrid://` | ✅ Supported |
 | pycubrid (Pure Python) | `pip install "sqlalchemy-cubrid[pycubrid]"` | `cubrid+pycubrid://` | ✅ Supported |
+| pycubrid async | `pip install "sqlalchemy-cubrid[pycubrid]"` | `cubrid+aiopycubrid://` | ✅ Supported |
 
 ---
 
@@ -64,6 +65,7 @@ These will be migrated to public APIs when SA 2.2 is released.
 | Feature | Status | Notes |
 |---|---|---|
 | `create_engine()` | ✅ | Both `cubrid://` and `cubrid+pycubrid://` schemes |
+| Async engine | ✅ | `create_async_engine("cubrid+aiopycubrid://...")` |
 | SQL compilation | ✅ | SELECT, INSERT, UPDATE, DELETE, JOIN, subqueries |
 | DDL compilation | ✅ | CREATE TABLE, ALTER, DROP, AUTO_INCREMENT, COMMENT |
 | Type system | ✅ | All CUBRID types mapped (see below) |
@@ -120,7 +122,7 @@ These will be migrated to public APIs when SA 2.2 is released.
 | RELEASE SAVEPOINT | ❌ | No-op (CUBRID doesn't support it) |
 | Lateral joins | ❌ | CUBRID lacks LATERAL subquery support |
 | Full-text search | ❌ | No MATCH … AGAINST syntax |
-| Async DBAPI | ❌ | CUBRID drivers have no async support |
+| Async DBAPI | ✅ | Via pycubrid.aio async driver (`cubrid+aiopycubrid://`) |
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ Issues = "https://github.com/cubrid-labs/sqlalchemy-cubrid/issues"
 cubrid = "sqlalchemy_cubrid.dialect:CubridDialect"
 "cubrid.cubrid" = "sqlalchemy_cubrid.dialect:CubridDialect"
 "cubrid.pycubrid" = "sqlalchemy_cubrid.pycubrid_dialect:PyCubridDialect"
+"cubrid.aiopycubrid" = "sqlalchemy_cubrid.aio_pycubrid_dialect:PyCubridAsyncDialect"
 
 [project.entry-points."alembic.ddl"]
 cubrid = "sqlalchemy_cubrid.alembic_impl:CubridImpl"

--- a/sqlalchemy_cubrid/aio_pycubrid_dialect.py
+++ b/sqlalchemy_cubrid/aio_pycubrid_dialect.py
@@ -1,0 +1,126 @@
+# sqlalchemy_cubrid/aio_pycubrid_dialect.py
+# Copyright (C) 2021-2026 by sqlalchemy-cubrid authors and contributors
+# <see AUTHORS file>
+#
+# This module is part of sqlalchemy-cubrid and is released under
+# the MIT License: http://www.opensource.org/licenses/mit-license.php
+
+from __future__ import annotations
+
+import collections
+from typing import Any, Callable, Optional, cast
+
+from sqlalchemy.connectors.asyncio import (
+    AsyncAdapt_dbapi_connection,
+    AsyncAdapt_dbapi_cursor,
+    AsyncAdapt_dbapi_module,
+)
+from sqlalchemy.engine.interfaces import ConnectArgsType, DBAPIModule
+from sqlalchemy.engine.url import URL
+from sqlalchemy.util.concurrency import await_only
+
+from sqlalchemy_cubrid.pycubrid_dialect import PyCubridDialect, PyCubridExecutionContext
+
+
+class AsyncAdapt_pycubrid_cursor(AsyncAdapt_dbapi_cursor):
+    _awaitable_cursor_close: bool = True
+
+    def setinputsizes(self, *inputsizes: Any) -> None:
+        pass
+
+    def nextset(self) -> None:
+        pass
+
+
+class AsyncAdapt_pycubrid_connection(AsyncAdapt_dbapi_connection):
+    _cursor_cls = AsyncAdapt_pycubrid_cursor
+
+    @property
+    def autocommit(self) -> bool:
+        return self._connection.autocommit  # type: ignore[union-attr]
+
+    @autocommit.setter
+    def autocommit(self, value: bool) -> None:
+        self.await_(self._connection.set_autocommit(value))  # type: ignore[union-attr]
+
+
+class AsyncAdapt_pycubrid_dbapi(AsyncAdapt_dbapi_module):
+    def __init__(self, aio_module: Any) -> None:
+        self._aio_module = aio_module
+
+        import pycubrid as sync_module
+
+        self.paramstyle = sync_module.paramstyle
+        self.Error = sync_module.Error
+        self.OperationalError = sync_module.OperationalError
+        self.InterfaceError = sync_module.InterfaceError
+        self.IntegrityError = sync_module.IntegrityError
+        self.ProgrammingError = sync_module.ProgrammingError
+        self.DatabaseError = sync_module.DatabaseError
+        self.InternalError = sync_module.InternalError
+        self.DataError = sync_module.DataError
+        self.NotSupportedError = sync_module.NotSupportedError
+        self.Warning = sync_module.Warning
+
+        self.STRING = sync_module.STRING
+        self.BINARY = sync_module.BINARY
+        self.NUMBER = sync_module.NUMBER
+        self.DATETIME = sync_module.DATETIME
+        self.ROWID = sync_module.ROWID
+
+    def connect(self, *arg: Any, **kw: Any) -> AsyncAdapt_pycubrid_connection:
+        creator_fn = kw.pop("async_creator_fn", self._aio_module.connect)
+        async_conn = await_only(creator_fn(*arg, **kw))
+        return AsyncAdapt_pycubrid_connection(self, async_conn)
+
+
+class PyCubridAsyncDialect(PyCubridDialect):
+    driver = "aiopycubrid"
+    is_async = True
+    supports_statement_cache = True
+    execution_ctx_cls = PyCubridExecutionContext
+
+    @classmethod
+    def import_dbapi(cls) -> DBAPIModule:
+        import pycubrid.aio as aio_module
+
+        return cast(DBAPIModule, AsyncAdapt_pycubrid_dbapi(aio_module))
+
+    @classmethod
+    def dbapi(cls) -> DBAPIModule:  # type: ignore[override]
+        return cls.import_dbapi()
+
+    def create_connect_args(self, url: URL) -> ConnectArgsType:
+        if url is None:
+            raise ValueError("Unexpected database URL format")
+
+        opts = url.translate_connect_args(username="user", database="database")
+        return (), {
+            "host": opts.get("host", "localhost"),
+            "port": opts.get("port", 33000),
+            "database": opts.get("database", ""),
+            "user": opts.get("user", "dba"),
+            "password": opts.get("password", ""),
+        }
+
+    def on_connect(self) -> Callable[[Any], None] | None:
+        isolation_level = self.isolation_level
+
+        def connect(conn: Any) -> None:
+            conn.autocommit = False
+            if isolation_level is not None:
+                self.set_isolation_level(conn, isolation_level)
+
+        return connect
+
+    def do_ping(self, dbapi_connection: Any) -> bool:
+        cursor = dbapi_connection.cursor()
+        try:
+            cursor.execute("SELECT 1")
+            cursor.fetchone()
+        finally:
+            cursor.close()
+        return True
+
+
+dialect = PyCubridAsyncDialect

--- a/test/test_aio_pycubrid_dialect.py
+++ b/test/test_aio_pycubrid_dialect.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import sys
+import types
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy.engine import url
+
+from sqlalchemy_cubrid.aio_pycubrid_dialect import (
+    AsyncAdapt_pycubrid_connection,
+    AsyncAdapt_pycubrid_cursor,
+    AsyncAdapt_pycubrid_dbapi,
+    PyCubridAsyncDialect,
+)
+
+
+class TestPyCubridAsyncDialectBasics:
+    def test_driver_name(self):
+        dialect = PyCubridAsyncDialect()
+        assert dialect.driver == "aiopycubrid"
+        assert dialect.name == "cubrid"
+
+    def test_is_async(self):
+        dialect = PyCubridAsyncDialect()
+        assert dialect.is_async is True
+
+    def test_supports_statement_cache(self):
+        dialect = PyCubridAsyncDialect()
+        assert dialect.supports_statement_cache is True
+
+    def test_inherits_cubrid_dialect_properties(self):
+        dialect = PyCubridAsyncDialect()
+        assert dialect.supports_native_boolean is False
+        assert dialect.supports_sequences is False
+        assert dialect.max_identifier_length == 254
+
+    def test_default_paramstyle(self):
+        dialect = PyCubridAsyncDialect()
+        assert dialect.default_paramstyle == "qmark"
+
+
+class TestPyCubridAsyncDialectImportDbapi:
+    def test_import_dbapi_returns_async_adapt_module(self):
+        fake_aio = types.ModuleType("pycubrid.aio")
+        fake_sync = types.ModuleType("pycubrid")
+        fake_sync.paramstyle = "qmark"  # type: ignore[attr-defined]
+        for attr in [
+            "Error",
+            "OperationalError",
+            "InterfaceError",
+            "IntegrityError",
+            "ProgrammingError",
+            "DatabaseError",
+            "InternalError",
+            "DataError",
+            "NotSupportedError",
+            "Warning",
+            "STRING",
+            "BINARY",
+            "NUMBER",
+            "DATETIME",
+            "ROWID",
+        ]:
+            setattr(fake_sync, attr, type(attr, (Exception,), {}))
+
+        with patch.dict(sys.modules, {"pycubrid.aio": fake_aio, "pycubrid": fake_sync}):
+            dbapi = PyCubridAsyncDialect.import_dbapi()
+
+        assert isinstance(dbapi, AsyncAdapt_pycubrid_dbapi)
+
+
+class TestPyCubridAsyncDialectConnectArgs:
+    def test_create_connect_args(self):
+        dialect = PyCubridAsyncDialect()
+        u = url.make_url("cubrid+aiopycubrid://dba:pass@myhost:33000/mydb")
+        args, kwargs = dialect.create_connect_args(u)
+        assert args == ()
+        assert kwargs["host"] == "myhost"
+        assert kwargs["port"] == 33000
+        assert kwargs["database"] == "mydb"
+        assert kwargs["user"] == "dba"
+        assert kwargs["password"] == "pass"
+
+    def test_create_connect_args_defaults(self):
+        dialect = PyCubridAsyncDialect()
+        u = url.make_url("cubrid+aiopycubrid:///")
+        args, kwargs = dialect.create_connect_args(u)
+        assert kwargs["host"] == "localhost"
+        assert kwargs["port"] == 33000
+        assert kwargs["user"] == "dba"
+        assert kwargs["password"] == ""
+
+
+class TestPyCubridAsyncDialectOnConnect:
+    def test_on_connect_sets_autocommit_false(self):
+        dialect = PyCubridAsyncDialect()
+        callback = dialect.on_connect()
+        assert callback is not None
+
+        conn = MagicMock()
+        callback(conn)
+        assert conn.autocommit is False
+
+    def test_on_connect_with_isolation_level(self):
+        dialect = PyCubridAsyncDialect(isolation_level="SERIALIZABLE")
+        callback = dialect.on_connect()
+        assert callback is not None
+
+        conn = MagicMock()
+        with patch.object(dialect, "set_isolation_level") as mock_set:
+            callback(conn)
+        mock_set.assert_called_once_with(conn, "SERIALIZABLE")
+
+
+class TestAsyncAdaptPycubridDbapi:
+    def test_connect_calls_aio_connect(self):
+        fake_aio = MagicMock()
+        fake_sync = MagicMock()
+        fake_sync.paramstyle = "qmark"
+
+        with patch.dict(sys.modules, {"pycubrid": fake_sync}):
+            dbapi = AsyncAdapt_pycubrid_dbapi(fake_aio)
+
+        assert dbapi.paramstyle == "qmark"
+        assert dbapi._aio_module is fake_aio
+
+    def test_exception_classes_from_sync_module(self):
+        fake_aio = MagicMock()
+        fake_sync = MagicMock()
+        fake_sync.paramstyle = "qmark"
+
+        class FakeError(Exception):
+            pass
+
+        fake_sync.Error = FakeError
+
+        with patch.dict(sys.modules, {"pycubrid": fake_sync}):
+            dbapi = AsyncAdapt_pycubrid_dbapi(fake_aio)
+
+        assert dbapi.Error is FakeError
+
+
+class TestAsyncAdaptPycubridConnection:
+    def test_autocommit_property_reads_underlying(self):
+        mock_dbapi = MagicMock()
+        mock_async_conn = MagicMock()
+        mock_async_conn.autocommit = True
+
+        conn = AsyncAdapt_pycubrid_connection(mock_dbapi, mock_async_conn)
+        assert conn.autocommit is True
+
+    def test_cursor_returns_adapted_cursor(self):
+        mock_dbapi = MagicMock()
+        mock_async_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_cursor.__aenter__ = AsyncMock(return_value=mock_cursor)
+        mock_async_conn.cursor.return_value = mock_cursor
+
+        conn = AsyncAdapt_pycubrid_connection(mock_dbapi, mock_async_conn)
+
+        with patch.object(conn, "await_", side_effect=lambda x: mock_cursor):
+            cur = conn.cursor()
+
+        assert isinstance(cur, AsyncAdapt_pycubrid_cursor)
+
+
+class TestAsyncAdaptPycubridCursor:
+    def test_setinputsizes_is_noop(self):
+        mock_conn = MagicMock(spec=AsyncAdapt_pycubrid_connection)
+        mock_conn._connection = MagicMock()
+        mock_async_cursor = MagicMock()
+        mock_async_cursor.__aenter__ = AsyncMock(return_value=mock_async_cursor)
+        mock_async_cursor.description = None
+        mock_conn._connection.cursor.return_value = mock_async_cursor
+        mock_conn.await_ = lambda x: mock_async_cursor
+        mock_conn._execute_mutex = MagicMock()
+
+        cur = AsyncAdapt_pycubrid_cursor(mock_conn)
+        cur.setinputsizes(10, 20)
+
+    def test_nextset_is_noop(self):
+        mock_conn = MagicMock(spec=AsyncAdapt_pycubrid_connection)
+        mock_conn._connection = MagicMock()
+        mock_async_cursor = MagicMock()
+        mock_async_cursor.__aenter__ = AsyncMock(return_value=mock_async_cursor)
+        mock_conn._connection.cursor.return_value = mock_async_cursor
+        mock_conn.await_ = lambda x: mock_async_cursor
+        mock_conn._execute_mutex = MagicMock()
+
+        cur = AsyncAdapt_pycubrid_cursor(mock_conn)
+        cur.nextset()
+
+
+class TestPyCubridAsyncDialectDoPing:
+    def test_do_ping_executes_select_1(self):
+        dialect = PyCubridAsyncDialect()
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+
+        result = dialect.do_ping(mock_conn)
+
+        mock_cursor.execute.assert_called_once_with("SELECT 1")
+        mock_cursor.fetchone.assert_called_once()
+        mock_cursor.close.assert_called_once()
+        assert result is True


### PR DESCRIPTION
## Summary

Add `PyCubridAsyncDialect` so that `create_async_engine("cubrid+aiopycubrid://...")` works with SQLAlchemy's AsyncSession/AsyncEngine.

Closes #109
Depends on: cubrid-labs/pycubrid#65 (pycubrid.aio)

## What's included

### New files
- `sqlalchemy_cubrid/aio_pycubrid_dialect.py` — async dialect + adapter classes
- `test/test_aio_pycubrid_dialect.py` — 17 offline tests

### Entry point
```toml
"cubrid.aiopycubrid" = "sqlalchemy_cubrid.aio_pycubrid_dialect:PyCubridAsyncDialect"
```

### Usage

```python
from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession

engine = create_async_engine("cubrid+aiopycubrid://dba@localhost:33000/testdb")

async with AsyncSession(engine) as session:
    result = await session.execute(text("SELECT 1"))
    print(result.scalar())
```

### Architecture
- `AsyncAdapt_pycubrid_dbapi` — wraps `pycubrid.aio` module, exposes sync `connect()` via `await_only`
- `AsyncAdapt_pycubrid_connection` — wraps `AsyncConnection`, autocommit property bridged via `await_only`
- `AsyncAdapt_pycubrid_cursor` — extends SA's base async cursor adapter
- `PyCubridAsyncDialect` — `is_async=True`, inherits all SQL compilation/type mapping from `PyCubridDialect`

### Test results
```
test/test_aio_pycubrid_dialect.py    17 passed
test/ (full suite)                  453 passed, 35 skipped
```