### PR TITLE
chore: add Makefile release target and CI version consistency check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,26 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  version-check:
+    name: Version consistency
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Check pyproject.toml matches __init__.py
+        run: |
+          PYPROJECT_VER=$(grep -oP '^version = "\K[^"]+' pyproject.toml)
+          INIT_VER=$(python3 -c "from sqlalchemy_cubrid import __version__; print(__version__)")
+          echo "pyproject.toml: $PYPROJECT_VER"
+          echo "__init__.py:    $INIT_VER"
+          if [ "$PYPROJECT_VER" != "$INIT_VER" ]; then
+            echo "::error::Version mismatch: pyproject.toml=$PYPROJECT_VER, __init__.py=$INIT_VER"
+            exit 1
+          fi
+          echo "Versions match: $PYPROJECT_VER"
+
   # ──────────────────────────────────────────
   # Job 1: Lint (fast, no DB needed)
   # ──────────────────────────────────────────

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install lint format typecheck security check check-all test test-all integration docker-up docker-down changelog clean clean-all doctor
+.PHONY: help install lint format typecheck security check check-all test test-all integration docker-up docker-down changelog clean clean-all doctor release
 
 PYTEST = python3 -m pytest
 RUFF = ruff
@@ -77,3 +77,16 @@ doctor: ## Check development environment
 	@$(BANDIT) --version || echo "ERROR: bandit not found"
 	@pre-commit --version || echo "ERROR: pre-commit not found"
 	@echo "All checks passed!"
+
+release: ## Bump version in pyproject.toml and __init__.py
+	@if [ -z "$(VERSION)" ]; then echo "Usage: make release VERSION=x.y.z"; exit 1; fi
+	@echo "Bumping version to $(VERSION)..."
+	@sed -i 's/^version = ".*"/version = "$(VERSION)"/' pyproject.toml
+	@sed -i 's/^__version__ = ".*"/__version__ = "$(VERSION)"/' sqlalchemy_cubrid/__init__.py
+	@echo "Verifying consistency..."
+	@PYPROJECT_VER=$$(grep -oP '^version = "\K[^"]+' pyproject.toml); \
+	 INIT_VER=$$(python3 -c "import ast; print(next(node.value.value for node in ast.walk(ast.parse(open('sqlalchemy_cubrid/__init__.py').read())) if isinstance(node, ast.Assign) and any(t.id == '__version__' for t in node.targets if isinstance(t, ast.Name))))"); \
+	 if [ "$$PYPROJECT_VER" != "$$INIT_VER" ]; then \
+	   echo "ERROR: Version mismatch — pyproject.toml=$$PYPROJECT_VER, __init__.py=$$INIT_VER"; exit 1; \
+	 fi
+	@echo "Version $(VERSION) set in pyproject.toml and sqlalchemy_cubrid/__init__.py"


### PR DESCRIPTION
Closes #112

## Summary
- Add `make release VERSION=x.y.z` target that bumps both pyproject.toml and __init__.py atomically with verification
- Add CI version consistency check job to catch mismatches on every PR