### PR TITLE
feat: add JSON type support (CUBRID 10.2+)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Check pyproject.toml matches __init__.py
         run: |
           PYPROJECT_VER=$(grep -oP '^version = "\K[^"]+' pyproject.toml)
-          INIT_VER=$(python3 -c "from sqlalchemy_cubrid import __version__; print(__version__)")
+          INIT_VER=$(python3 -c "import ast; print(next(node.value.value for node in ast.walk(ast.parse(open('sqlalchemy_cubrid/__init__.py').read())) if isinstance(node, ast.Assign) and any(t.id == '__version__' for t in node.targets if isinstance(t, ast.Name))))")
           echo "pyproject.toml: $PYPROJECT_VER"
           echo "__init__.py:    $INIT_VER"
           if [ "$PYPROJECT_VER" != "$INIT_VER" ]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2026-04-18
+
+### Added
+
+- **JSON type support** (CUBRID 10.2+)
+  - `JSON` type class subclassing `sqltypes.JSON`
+  - `JSONIndexType` and `JSONPathType` for path expression formatting
+    (with embedded-quote escaping per CUBRID JSON path grammar)
+  - `visit_JSON` type compiler emitting `JSON` DDL
+  - JSON path expressions via `JSON_EXTRACT` (`col["key"]`, `col[("a", "b")]`)
+  - Typed access via `as_boolean`, `as_integer`, `as_numeric`, `as_float`, `as_string`
+    using CASE / CAST / `JSON_UNQUOTE` as appropriate
+  - JSON null → SQL NULL handling with CASE expressions for typed access
+  - `colspecs` mapping: generic `sa.JSON` → dialect `JSON`
+  - `ischema_names` mapping: `"JSON"` → `JSON` for reflection
+  - 47 offline tests (`test/test_json.py`)
+
+### Fixed
+
+- Version consistency: synchronized `__version__` in `sqlalchemy_cubrid/__init__.py`
+  with `pyproject.toml` (was 1.0.0 vs 1.1.0)
+- Removed unused imports flagged by `ruff` in `aio_pycubrid_dialect.py` and
+  `test/test_aio_pycubrid_dialect.py`
+
 ## [1.1.0] - 2026-04-18
 
 ### Added
@@ -16,16 +40,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `AsyncAdapt_pycubrid_cursor` with full async cursor adaptation
   - `cubrid.aiopycubrid` entry point auto-discovered by SQLAlchemy
 - 17 new async dialect offline tests (`test/test_aio_pycubrid_dialect.py`)
-
-- **JSON type support** (CUBRID 10.2+)
-  - `JSON` type class subclassing `sqltypes.JSON`
-  - `JSONIndexType` and `JSONPathType` for path expression formatting
-  - `visit_JSON` type compiler emitting `JSON` DDL
-  - JSON path expressions via `JSON_EXTRACT` (`col["key"]`, `col[("a", "b")]`)
-  - JSON null → SQL NULL handling with CASE expressions for typed access
-  - `colspecs` mapping: generic `sa.JSON` → dialect `JSON`
-  - `ischema_names` mapping: `"JSON"` → `JSON` for reflection
-  - 32 offline tests (`test/test_json.py`)
 
 ## [1.0.0] - 2026-04-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.1.0] - 2026-04-18
 
 ### Added
+
 - **Async dialect** via `cubrid+aiopycubrid://` URL scheme
   - `PyCubridAsyncDialect` (`is_async=True`) using SQLAlchemy's `AsyncAdapt_dbapi_*` base classes
   - `AsyncAdapt_pycubrid_dbapi` wraps `pycubrid.aio` module
@@ -15,6 +16,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `AsyncAdapt_pycubrid_cursor` with full async cursor adaptation
   - `cubrid.aiopycubrid` entry point auto-discovered by SQLAlchemy
 - 17 new async dialect offline tests (`test/test_aio_pycubrid_dialect.py`)
+
+- **JSON type support** (CUBRID 10.2+)
+  - `JSON` type class subclassing `sqltypes.JSON`
+  - `JSONIndexType` and `JSONPathType` for path expression formatting
+  - `visit_JSON` type compiler emitting `JSON` DDL
+  - JSON path expressions via `JSON_EXTRACT` (`col["key"]`, `col[("a", "b")]`)
+  - JSON null → SQL NULL handling with CASE expressions for typed access
+  - `colspecs` mapping: generic `sa.JSON` → dialect `JSON`
+  - `ischema_names` mapping: `"JSON"` → `JSON` for reflection
+  - 32 offline tests (`test/test_json.py`)
 
 ## [1.0.0] - 2026-04-11
 
@@ -35,7 +46,7 @@ breaking changes will only occur in major version bumps (2.0+).
 - `RETURNING` clauses not supported (CUBRID limitation)
 - No `Sequence` support (CUBRID uses `AUTO_INCREMENT`)
 - Native `BOOLEAN` not available (mapped to `SMALLINT`)
-- Lateral joins, JSON type, and writable CTEs not supported
+- Lateral joins and writable CTEs not supported
 - `RELEASE SAVEPOINT` is a no-op
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ async with AsyncSession(engine) as session:
 
 ## Features
 
-- Complete type system -- numeric, string, date/time, bit, LOB, and collection types
+- Complete type system -- numeric, string, date/time, bit, LOB, collection, and JSON types
 - SQL compilation -- SELECT, JOIN, CAST, LIMIT/OFFSET, subqueries, CTEs, window functions
 - DML extensions -- `ON DUPLICATE KEY UPDATE`, `MERGE`, `REPLACE INTO`, `FOR UPDATE`, `TRUNCATE`
 - DDL support -- `COMMENT`, `IF NOT EXISTS` / `IF EXISTS`, `AUTO_INCREMENT`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -34,3 +34,8 @@ Python 3.10+, SQLAlchemy 2.0–2.1, CUBRID 10.2–11.4
 - `cubrid+aiopycubrid://` URL scheme via `PyCubridAsyncDialect`
 - Full `create_async_engine` / `AsyncSession` support
 - Requires pycubrid >= 1.1.0 with async module
+
+### JSON Type Support
+- Native JSON type with `JSON_EXTRACT`-based path expressions
+- `col["key"]` and `col[("a", "b")]` indexing compiled to CUBRID SQL
+- Full colspecs/ischema_names integration for reflection

--- a/docs/FEATURE_SUPPORT.md
+++ b/docs/FEATURE_SUPPORT.md
@@ -166,7 +166,7 @@ High-level overview by feature category.
 | Type | CUBRID | MySQL | PostgreSQL | SQLite |
 |------|--------|-------|------------|--------|
 | ENUM | ❌ | ✅ | ✅ | ❌ |
-| JSON | ❌ | ✅ | ✅ | ⚠️ |
+| JSON | ✅ | ✅ | ✅ | ⚠️ |
 | ARRAY | ❌ | ❌ | ✅ | ❌ |
 | UUID | ❌ | ❌ | ✅ | ❌ |
 | INTERVAL | ❌ | ❌ | ✅ | ❌ |
@@ -176,7 +176,7 @@ High-level overview by feature category.
 
 - **BOOLEAN**: CUBRID maps `BOOLEAN` to `SMALLINT`. MySQL maps it to `TINYINT(1)`. SQLite stores booleans as integers. Only PostgreSQL has a native `BOOLEAN` type.
 - **NCHAR / NVARCHAR**: CUBRID has first-class national character types. MySQL handles national characters via column charset. PostgreSQL and SQLite have no separate national character types.
-- **JSON**: CUBRID does not have a JSON data type or JSON functions. MySQL (5.7+) and PostgreSQL have native JSON support. SQLite has JSON functions but no dedicated column type.
+- **JSON**: CUBRID 10.2+ has native JSON support (RFC 7159) with 25+ JSON functions. The dialect supports `JSON` type, `col["key"]` path expressions via `JSON_EXTRACT`, and typed access (`as_string()`, `as_integer()`, `as_float()`). MySQL (5.7+) and PostgreSQL also have native JSON support. SQLite has JSON functions but no dedicated column type.
 - **ARRAY**: CUBRID uses collection types (`SET`, `MULTISET`, `SEQUENCE`) which serve a similar purpose but are not SQL-standard arrays. PostgreSQL has native `ARRAY[]` support.
 - **CLOB**: CUBRID and MySQL have explicit `CLOB` types. PostgreSQL uses `TEXT` (unlimited length). SQLite stores all text as `TEXT`.
 
@@ -464,7 +464,7 @@ Features not currently supported that may be added in future releases, depending
 |---------|--------|--------|
 | RETURNING clause | ❌ | CUBRID does not support `INSERT/UPDATE/DELETE … RETURNING` |
 | Postfetch LASTROWID | ❌ | CUBRID Python driver limitation |
-| JSON type | ❌ | CUBRID does not have a JSON data type |
+| JSON type | ✅ | Native JSON support (CUBRID 10.2+) with path expressions via `JSON_EXTRACT` |
 | Temporary tables | ❌ | CUBRID does not support `CREATE TEMPORARY TABLE` |
 | Multiple schemas | ❌ | CUBRID operates in a single-schema model |
 | IS DISTINCT FROM | ❌ | Not a CUBRID SQL operator |

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -22,7 +22,7 @@ A complete ground-up rewrite delivering a production-ready CUBRID dialect:
 
 - **Full SQLAlchemy 2.0–2.1 dialect** with statement caching
 - **Complete SQL feature coverage** — everything CUBRID supports is enabled
-- **Comprehensive type system** — 20+ types including CUBRID-specific collections
+- **Comprehensive type system** — 20+ types including CUBRID-specific collections and JSON
 - **Schema reflection** — tables, views, columns, PKs, FKs, indexes, unique constraints, comments
 - **DML extensions** — ON DUPLICATE KEY UPDATE, MERGE, GROUP_CONCAT, TRUNCATE
 - **DDL support** — COMMENT, IF NOT EXISTS / IF EXISTS, AUTO_INCREMENT

--- a/docs/TYPES.md
+++ b/docs/TYPES.md
@@ -64,6 +64,8 @@ from sqlalchemy_cubrid import (
     BLOB, CLOB,
     # Collections
     SET, MULTISET, SEQUENCE,
+    # JSON
+    JSON,
 )
 ```
 
@@ -187,6 +189,48 @@ CREATE TABLE tagged_items (
 ```
 
 > **Note**: Collection types are CUBRID-specific. Standard SQL uses `ARRAY[]` (PostgreSQL) or has no collection support. If portability is a concern, use `SET`/`MULTISET`/`SEQUENCE` only when targeting CUBRID.
+
+### JSON Type
+
+CUBRID 10.2+ supports native JSON (RFC 7159). The dialect provides full JSON type support:
+
+| Type             | CUBRID SQL | Description                              |
+|------------------|------------|------------------------------------------|
+| `JSON`           | `JSON`     | Native JSON storage (RFC 7159 compliant) |
+| `JSONIndexType`  | —          | Single-key path formatting (`$."key"`)   |
+| `JSONPathType`   | —          | Multi-level path formatting              |
+
+```python
+from sqlalchemy_cubrid import JSON
+from sqlalchemy import Column, Integer, Table, MetaData, func, select
+
+metadata = MetaData()
+events = Table(
+    "events", metadata,
+    Column("id", Integer, primary_key=True),
+    Column("payload", JSON),
+)
+```
+
+**Path expressions** use `JSON_EXTRACT` under the hood:
+
+```python
+# Single key access: col["key"] → JSON_EXTRACT(col, '$."key"')
+stmt = select(events.c.payload["type"])
+
+# Nested path: col[("a", "b")] → JSON_EXTRACT(col, '$."a"."b"')
+stmt = select(events.c.payload[("data", "name")])
+
+# Typed access with null handling
+stmt = select(events).where(
+    events.c.payload["status"].as_string() == "active"
+)
+
+# Direct function usage
+stmt = select(func.JSON_EXTRACT(events.c.payload, "$.type"))
+```
+
+> **Note**: Generic `sa.JSON` is automatically adapted to CUBRID's `JSON` type via `colspecs`. JSON columns are reflected correctly from existing tables.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sqlalchemy-cubrid"
-version = "1.1.0"
+version = "1.2.0"
 description = "CUBRID dialect for SQLAlchemy"
 readme = "README.md"
 license = "MIT"

--- a/sqlalchemy_cubrid/__init__.py
+++ b/sqlalchemy_cubrid/__init__.py
@@ -25,6 +25,9 @@ from .types import (
     DOUBLE,
     DOUBLE_PRECISION,
     FLOAT,
+    JSON,
+    JSONIndexType,
+    JSONPathType,
     MONETARY,
     MULTISET,
     NCHAR,
@@ -82,4 +85,7 @@ __all__ = (
     "MULTISET",
     "SEQUENCE",
     "OBJECT",
+    "JSON",
+    "JSONIndexType",
+    "JSONPathType",
 )

--- a/sqlalchemy_cubrid/__init__.py
+++ b/sqlalchemy_cubrid/__init__.py
@@ -52,7 +52,7 @@ from sqlalchemy.sql.sqltypes import (
     TIMESTAMP,
 )
 
-__version__ = "1.0.0"
+__version__ = "1.2.0"
 
 __all__ = (
     "insert",

--- a/sqlalchemy_cubrid/aio_pycubrid_dialect.py
+++ b/sqlalchemy_cubrid/aio_pycubrid_dialect.py
@@ -7,8 +7,7 @@
 
 from __future__ import annotations
 
-import collections
-from typing import Any, Callable, Optional, cast
+from typing import Any, Callable, cast
 
 from sqlalchemy.connectors.asyncio import (
     AsyncAdapt_dbapi_connection,

--- a/sqlalchemy_cubrid/compiler.py
+++ b/sqlalchemy_cubrid/compiler.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from sqlalchemy.sql import compiler
+from sqlalchemy.sql import compiler, elements
 from sqlalchemy.sql import sqltypes
 
 
@@ -320,6 +320,56 @@ class CubridCompiler(compiler.SQLCompiler):
             return "REPLACE" + text[len("INSERT") :]
         return text
 
+    def _render_json_extract_from_binary(
+        self, binary: elements.BinaryExpression[Any], operator: Any, **kw: Any
+    ) -> str:
+        if binary.type._type_affinity is sqltypes.JSON:
+            return "JSON_EXTRACT(%s, %s)" % (
+                self.process(binary.left, **kw),
+                self.process(binary.right, **kw),
+            )
+
+        # When the target type is not JSON, convert JSON 'null' to SQL NULL
+        case_expression = "CASE JSON_EXTRACT(%s, %s) WHEN 'null' THEN NULL" % (
+            self.process(binary.left, **kw),
+            self.process(binary.right, **kw),
+        )
+
+        if binary.type._type_affinity is sqltypes.Boolean:
+            type_expression = (
+                "WHEN 'true' THEN 1 WHEN 'false' THEN 0 ELSE CAST(JSON_EXTRACT(%s, %s) AS INTEGER)"
+            ) % (
+                self.process(binary.left, **kw),
+                self.process(binary.right, **kw),
+            )
+        elif binary.type._type_affinity is sqltypes.Integer:
+            type_expression = "ELSE CAST(JSON_EXTRACT(%s, %s) AS INTEGER)" % (
+                self.process(binary.left, **kw),
+                self.process(binary.right, **kw),
+            )
+        elif binary.type._type_affinity is sqltypes.Numeric:
+            type_expression = "ELSE CAST(JSON_EXTRACT(%s, %s) AS DOUBLE)" % (
+                self.process(binary.left, **kw),
+                self.process(binary.right, **kw),
+            )
+        else:
+            type_expression = "ELSE JSON_UNQUOTE(JSON_EXTRACT(%s, %s))" % (
+                self.process(binary.left, **kw),
+                self.process(binary.right, **kw),
+            )
+
+        return case_expression + " " + type_expression + " END"
+
+    def visit_json_getitem_op_binary(
+        self, binary: elements.BinaryExpression[Any], operator: Any, **kw: Any
+    ) -> str:
+        return self._render_json_extract_from_binary(binary, operator, **kw)
+
+    def visit_json_path_getitem_op_binary(
+        self, binary: elements.BinaryExpression[Any], operator: Any, **kw: Any
+    ) -> str:
+        return self._render_json_extract_from_binary(binary, operator, **kw)
+
 
 class CubridDDLCompiler(compiler.DDLCompiler):
     """DDLCompiler subclass for CUBRID.
@@ -534,3 +584,6 @@ class CubridTypeCompiler(compiler.GenericTypeCompiler):
             else:
                 parts.append(value.__visit_name__)
         return f"{collection_type}({','.join(parts)})"
+
+    def visit_JSON(self, type_: Any, **kw: Any) -> str:
+        return "JSON"

--- a/sqlalchemy_cubrid/dialect.py
+++ b/sqlalchemy_cubrid/dialect.py
@@ -48,6 +48,9 @@ from sqlalchemy_cubrid.types import (
     DOUBLE,
     DOUBLE_PRECISION,
     FLOAT,
+    JSON,
+    JSONIndexType,
+    JSONPathType,
     MULTISET,
     NCHAR,
     NUMERIC,
@@ -84,6 +87,9 @@ colspecs = {
     sqltypes.Numeric: NUMERIC,
     sqltypes.Float: FLOAT,
     sqltypes.Time: TIME,
+    sqltypes.JSON: JSON,
+    sqltypes.JSON.JSONIndexType: JSONIndexType,
+    sqltypes.JSON.JSONPathType: JSONPathType,
 }
 
 # ischema_names maps CUBRID type names from SHOW COLUMNS to SA types.
@@ -120,6 +126,8 @@ ischema_names = {
     "SET": SET,
     "MULTISET": MULTISET,
     "SEQUENCE": SEQUENCE,
+    # JSON (CUBRID 10.2+)
+    "JSON": JSON,
 }
 
 

--- a/sqlalchemy_cubrid/types.py
+++ b/sqlalchemy_cubrid/types.py
@@ -354,3 +354,92 @@ class OBJECT(sqltypes.TypeEngine[Any]):
     """
 
     __visit_name__ = "OBJECT"
+
+
+# ---------------------------------------------------------------------------
+# JSON Type (CUBRID 10.2+)
+# ---------------------------------------------------------------------------
+
+
+class _FormatTypeMixin:
+    """Mixin for formatting JSON path index/path values for bind parameters."""
+
+    def _format_value(self, value: Any) -> str:
+        raise NotImplementedError()
+
+    def bind_processor(self, dialect: Any) -> Any:
+        super_proc = self.string_bind_processor(dialect)  # type: ignore[attr-defined]  # noqa: E501
+
+        def process(value: Any) -> Any:
+            value = self._format_value(value)
+            if super_proc:
+                value = super_proc(value)
+            return value
+
+        return process
+
+    def literal_processor(self, dialect: Any) -> Any:
+        super_proc = self.string_literal_processor(dialect)  # type: ignore[attr-defined]  # noqa: E501
+
+        def process(value: Any) -> str:
+            value = self._format_value(value)
+            if super_proc:
+                value = super_proc(value)
+            return value
+
+        return process
+
+
+class JSONIndexType(_FormatTypeMixin, sqltypes.JSON.JSONIndexType):
+    """CUBRID JSON index type for single-key access.
+
+    Converts Python index values to CUBRID JSON path syntax:
+    - Integer index: ``$[0]``
+    - String key: ``$."key"``
+    """
+
+    def _format_value(self, value: Any) -> str:
+        if isinstance(value, int):
+            return "$[%s]" % value
+        else:
+            return '$."%s"' % str(value).replace('"', '""')
+
+
+class JSONPathType(_FormatTypeMixin, sqltypes.JSON.JSONPathType):
+    """CUBRID JSON path type for multi-level access.
+
+    Converts Python tuple paths to CUBRID JSON path syntax:
+    - ``("a", 1, "b")`` → ``$."a"[1]."b"``
+    """
+
+    def _format_value(self, value: Any) -> str:
+        return "$%s" % (
+            "".join(
+                "[%s]" % elem if isinstance(elem, int) else '."%s"' % str(elem).replace('"', '""')
+                for elem in value
+            )
+        )
+
+
+class JSON(sqltypes.JSON):  # type: ignore[type-arg]
+    """CUBRID JSON type.
+
+    CUBRID supports JSON as of version 10.2 (RFC 7159 compliant).
+
+    :class:`_cubrid.JSON` is used automatically whenever the base
+    :class:`_types.JSON` datatype is used against a CUBRID backend.
+
+    The :class:`.cubrid.JSON` type supports persistence of JSON values
+    as well as the core index operations provided by :class:`_types.JSON`
+    datatype, by adapting the operations to render the ``JSON_EXTRACT``
+    function at the database level.
+
+    .. seealso::
+
+        :class:`_types.JSON` - main documentation for the generic
+        cross-platform JSON datatype.
+
+    .. versionadded:: 1.2.0
+    """
+
+    __visit_name__ = "JSON"

--- a/test/test_aio_pycubrid_dialect.py
+++ b/test/test_aio_pycubrid_dialect.py
@@ -2,10 +2,8 @@ from __future__ import annotations
 
 import sys
 import types
-from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
 from sqlalchemy.engine import url
 
 from sqlalchemy_cubrid.aio_pycubrid_dialect import (

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -36,7 +36,7 @@ from sqlalchemy import (
     select,
     text,
 )
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -587,7 +587,6 @@ class TestFetchShapeCompatibility:
         execute successfully against a live CUBRID instance, confirming
         the dialect's use_insertmanyvalues=True is honored end-to-end.
         """
-        from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
         class _Base(DeclarativeBase):
             pass

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -595,22 +595,20 @@ class TestFetchShapeCompatibility:
         class BulkUser(_Base):
             __tablename__ = "imv_bulk_test"
             id: Mapped[int] = mapped_column(
-                Integer, primary_key=True, autoincrement=True,
+                Integer,
+                primary_key=True,
+                autoincrement=True,
             )
             name: Mapped[str] = mapped_column(String(100))
 
         _Base.metadata.create_all(engine)
         try:
             with Session(engine) as session:
-                session.add_all(
-                    [BulkUser(name=f"user_{i}") for i in range(10)]
-                )
+                session.add_all([BulkUser(name=f"user_{i}") for i in range(10)])
                 session.commit()
 
             with engine.connect() as conn:
-                count = conn.execute(
-                    text("SELECT COUNT(*) FROM imv_bulk_test")
-                ).scalar()
+                count = conn.execute(text("SELECT COUNT(*) FROM imv_bulk_test")).scalar()
                 assert count == 10
         finally:
             _Base.metadata.drop_all(engine)

--- a/test/test_json.py
+++ b/test/test_json.py
@@ -1,11 +1,10 @@
 # test/test_json.py
 from __future__ import annotations
 
-import json
 
 import pytest
 import sqlalchemy as sa
-from sqlalchemy import Column, Integer, MetaData, String, Table, func, select, text
+from sqlalchemy import Column, Integer, MetaData, String, Table, func, select
 
 from sqlalchemy_cubrid.dialect import CubridDialect
 from sqlalchemy_cubrid.types import JSON, JSONIndexType, JSONPathType

--- a/test/test_json.py
+++ b/test/test_json.py
@@ -1,0 +1,255 @@
+# test/test_json.py
+from __future__ import annotations
+
+import json
+
+import sqlalchemy as sa
+from sqlalchemy import Column, Integer, MetaData, String, Table, func, select, text
+
+from sqlalchemy_cubrid.dialect import CubridDialect
+from sqlalchemy_cubrid.types import JSON, JSONIndexType, JSONPathType
+
+
+def _compile(stmt, dialect=None):
+    if dialect is None:
+        dialect = CubridDialect()
+    return stmt.compile(dialect=dialect, compile_kwargs={"literal_binds": True}).string
+
+
+metadata = MetaData()
+json_table = Table(
+    "json_test",
+    metadata,
+    Column("id", Integer, primary_key=True),
+    Column("data", JSON),
+    Column("name", String(100)),
+)
+
+
+class TestJSONType:
+    def test_visit_name(self):
+        assert JSON.__visit_name__ == "JSON"
+
+    def test_is_subclass_of_sa_json(self):
+        from sqlalchemy.sql import sqltypes
+
+        assert issubclass(JSON, sqltypes.JSON)
+
+    def test_instantiation(self):
+        t = JSON()
+        assert t is not None
+
+    def test_none_as_null_parameter(self):
+        t = JSON(none_as_null=True)
+        assert t.none_as_null is True
+
+
+class TestJSONDDLCompilation:
+    def test_json_column_ddl(self):
+        dialect = CubridDialect()
+        compiled = dialect.type_compiler_instance.process(JSON())
+        assert compiled == "JSON"
+
+    def test_generic_sa_json_compiles_to_json(self):
+        tbl = Table(
+            "ddl_test",
+            MetaData(),
+            Column("id", Integer, primary_key=True),
+            Column("payload", sa.JSON),
+        )
+        dialect = CubridDialect()
+        create_ddl = sa.schema.CreateTable(tbl).compile(dialect=dialect).string
+        assert "JSON" in create_ddl
+
+    def test_cubrid_json_compiles_to_json(self):
+        tbl = Table(
+            "ddl_test2",
+            MetaData(),
+            Column("id", Integer, primary_key=True),
+            Column("payload", JSON),
+        )
+        dialect = CubridDialect()
+        create_ddl = sa.schema.CreateTable(tbl).compile(dialect=dialect).string
+        assert "JSON" in create_ddl
+
+
+class TestJSONIndexType:
+    def test_format_integer_index(self):
+        idx = JSONIndexType()
+        assert idx._format_value(0) == "$[0]"
+        assert idx._format_value(3) == "$[3]"
+
+    def test_format_string_key(self):
+        idx = JSONIndexType()
+        assert idx._format_value("name") == '$."name"'
+        assert idx._format_value("address") == '$."address"'
+
+
+class TestJSONPathType:
+    def test_format_simple_path(self):
+        pth = JSONPathType()
+        assert pth._format_value(("a",)) == '$."a"'
+
+    def test_format_nested_path(self):
+        pth = JSONPathType()
+        assert pth._format_value(("a", "b", "c")) == '$."a"."b"."c"'
+
+    def test_format_mixed_path(self):
+        pth = JSONPathType()
+        assert pth._format_value(("a", 1, "b")) == '$."a"[1]."b"'
+
+    def test_format_array_only_path(self):
+        pth = JSONPathType()
+        assert pth._format_value((0, 1, 2)) == "$[0][1][2]"
+
+
+class TestJSONPathExpressionCompilation:
+    def test_json_getitem_string_key(self):
+        stmt = select(json_table.c.data["name"])
+        sql = _compile(stmt)
+        assert "JSON_EXTRACT" in sql
+
+    def test_json_getitem_integer_index(self):
+        stmt = select(json_table.c.data[0])
+        sql = _compile(stmt)
+        assert "JSON_EXTRACT" in sql
+
+    def test_json_path_getitem(self):
+        stmt = select(json_table.c.data[("a", "b")])
+        sql = _compile(stmt)
+        assert "JSON_EXTRACT" in sql
+
+    def test_json_getitem_in_where(self):
+        stmt = select(json_table).where(json_table.c.data["status"].as_string() == "active")
+        sql = _compile(stmt)
+        assert "JSON_EXTRACT" in sql
+        assert "JSON_UNQUOTE" in sql
+
+    def test_json_getitem_as_integer(self):
+        stmt = select(json_table).where(json_table.c.data["count"].as_integer() > 5)
+        sql = _compile(stmt)
+        assert "JSON_EXTRACT" in sql
+        assert "CAST" in sql
+        assert "INTEGER" in sql
+
+    def test_json_getitem_as_float(self):
+        stmt = select(json_table).where(json_table.c.data["score"].as_float() > 3.5)
+        sql = _compile(stmt)
+        assert "JSON_EXTRACT" in sql
+        assert "CAST" in sql
+        assert "DOUBLE" in sql
+
+    def test_json_null_handling_for_string(self):
+        stmt = select(json_table.c.data["name"].as_string())
+        sql = _compile(stmt)
+        assert "WHEN 'null' THEN NULL" in sql
+
+    def test_json_getitem_as_boolean(self):
+        stmt = select(json_table).where(
+            json_table.c.data["active"].as_boolean() == True  # noqa: E712
+        )
+        sql = _compile(stmt)
+        assert "WHEN 'true' THEN 1" in sql
+        assert "WHEN 'false' THEN 0" in sql
+
+
+class TestJSONKeyEscaping:
+    def test_key_with_embedded_quote(self):
+        idx = JSONIndexType()
+        assert idx._format_value('a"b') == '$."a""b"'
+
+    def test_key_with_dot(self):
+        idx = JSONIndexType()
+        assert idx._format_value("a.b") == '$."a.b"'
+
+    def test_key_with_space(self):
+        idx = JSONIndexType()
+        assert idx._format_value("a b") == '$."a b"'
+
+    def test_empty_string_key(self):
+        idx = JSONIndexType()
+        assert idx._format_value("") == '$.""'
+
+    def test_path_with_embedded_quote(self):
+        pth = JSONPathType()
+        assert pth._format_value(('a"b', "c")) == '$."a""b"."c"'
+
+
+class TestFuncJSONExtract:
+    def test_func_json_extract(self):
+        stmt = select(func.JSON_EXTRACT(json_table.c.data, "$.name"))
+        sql = _compile(stmt)
+        assert "JSON_EXTRACT" in sql
+        assert "$.name" in sql
+
+    def test_func_json_contains(self):
+        stmt = select(json_table).where(
+            func.JSON_CONTAINS(json_table.c.data, '"value"', "$.key") == 1
+        )
+        sql = _compile(stmt)
+        assert "JSON_CONTAINS" in sql
+
+    def test_func_json_object(self):
+        stmt = select(func.JSON_OBJECT("key", "value"))
+        sql = _compile(stmt)
+        assert "JSON_OBJECT" in sql
+
+    def test_func_json_array(self):
+        stmt = select(func.JSON_ARRAY(1, 2, 3))
+        sql = _compile(stmt)
+        assert "JSON_ARRAY" in sql
+
+
+class TestColspecs:
+    def test_generic_json_maps_to_cubrid_json(self):
+        from sqlalchemy_cubrid.dialect import colspecs
+        from sqlalchemy.sql import sqltypes
+
+        assert sqltypes.JSON in colspecs
+        assert colspecs[sqltypes.JSON] is JSON
+
+    def test_json_index_type_mapped(self):
+        from sqlalchemy_cubrid.dialect import colspecs
+        from sqlalchemy.sql import sqltypes
+
+        assert sqltypes.JSON.JSONIndexType in colspecs
+        assert colspecs[sqltypes.JSON.JSONIndexType] is JSONIndexType
+
+    def test_json_path_type_mapped(self):
+        from sqlalchemy_cubrid.dialect import colspecs
+        from sqlalchemy.sql import sqltypes
+
+        assert sqltypes.JSON.JSONPathType in colspecs
+        assert colspecs[sqltypes.JSON.JSONPathType] is JSONPathType
+
+
+class TestIschemaNames:
+    def test_json_in_ischema_names(self):
+        from sqlalchemy_cubrid.dialect import ischema_names
+
+        assert "JSON" in ischema_names
+        assert ischema_names["JSON"] is JSON
+
+
+class TestJSONExport:
+    def test_json_in_init_all(self):
+        import sqlalchemy_cubrid
+
+        assert "JSON" in sqlalchemy_cubrid.__all__
+        assert "JSONIndexType" in sqlalchemy_cubrid.__all__
+        assert "JSONPathType" in sqlalchemy_cubrid.__all__
+
+    def test_json_importable(self):
+        from sqlalchemy_cubrid import JSON as ImportedJSON
+
+        assert ImportedJSON is JSON
+
+    def test_json_index_type_importable(self):
+        from sqlalchemy_cubrid import JSONIndexType as ImportedJIT
+
+        assert ImportedJIT is JSONIndexType
+
+    def test_json_path_type_importable(self):
+        from sqlalchemy_cubrid import JSONPathType as ImportedJPT
+
+        assert ImportedJPT is JSONPathType

--- a/test/test_json.py
+++ b/test/test_json.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 
+import pytest
 import sqlalchemy as sa
 from sqlalchemy import Column, Integer, MetaData, String, Table, func, select, text
 
@@ -253,3 +254,60 @@ class TestJSONExport:
         from sqlalchemy_cubrid import JSONPathType as ImportedJPT
 
         assert ImportedJPT is JSONPathType
+
+
+class TestFormatTypeMixinProcessors:
+    def _dialect(self):
+        from sqlalchemy_cubrid.dialect import CubridDialect
+
+        return CubridDialect()
+
+    def test_format_value_not_implemented(self):
+        from sqlalchemy_cubrid.types import _FormatTypeMixin
+
+        with pytest.raises(NotImplementedError):
+            _FormatTypeMixin()._format_value("anything")
+
+    def test_index_bind_processor_int(self):
+        proc = JSONIndexType().bind_processor(self._dialect())
+        assert proc is not None
+        assert proc(0) == "$[0]"
+
+    def test_index_bind_processor_string_escapes(self):
+        proc = JSONIndexType().bind_processor(self._dialect())
+        assert proc('a"b') == '$."a""b"'
+
+    def test_index_literal_processor_int(self):
+        proc = JSONIndexType().literal_processor(self._dialect())
+        assert proc is not None
+        result = proc(2)
+        assert "$[2]" in result
+
+    def test_index_literal_processor_string(self):
+        proc = JSONIndexType().literal_processor(self._dialect())
+        result = proc("name")
+        assert '$."name"' in result
+
+    def test_path_bind_processor(self):
+        proc = JSONPathType().bind_processor(self._dialect())
+        assert proc is not None
+        assert proc(("a", 1, "b")) == '$."a"[1]."b"'
+
+    def test_path_literal_processor(self):
+        proc = JSONPathType().literal_processor(self._dialect())
+        result = proc(("x", 0))
+        assert '$."x"[0]' in result
+
+    def test_index_bind_processor_no_super(self, monkeypatch):
+        """Cover the branch where string_bind_processor returns None."""
+        idx = JSONIndexType()
+        monkeypatch.setattr(idx, "string_bind_processor", lambda dialect: None)
+        proc = idx.bind_processor(self._dialect())
+        assert proc("k") == '$."k"'
+
+    def test_index_literal_processor_no_super(self, monkeypatch):
+        """Cover the branch where string_literal_processor returns None."""
+        idx = JSONIndexType()
+        monkeypatch.setattr(idx, "string_literal_processor", lambda dialect: None)
+        proc = idx.literal_processor(self._dialect())
+        assert proc("k") == '$."k"'


### PR DESCRIPTION
## Summary

Adds native JSON type support for CUBRID 10.2+, following the SQLAlchemy MySQL dialect pattern with CUBRID-specific path expression compilation.

Closes #114

## What's Included

### Type System
- **`JSON`** — subclasses `sqltypes.JSON`; auto-mapped from generic `sa.JSON` via `colspecs`
- **`JSONIndexType`** — formats single-key access (`$."key"`, `$[0]`) with embedded-quote escaping
- **`JSONPathType`** — formats multi-level paths (`$."a"[1]."b"`) with embedded-quote escaping

### SQL Compilation
- `visit_JSON` emits `JSON` DDL
- `_render_json_extract_from_binary` compiles `col["key"]` and `col[("a", "b")]` to `JSON_EXTRACT()`
- Typed access with JSON null → SQL NULL handling:
  - `as_string()` → `JSON_UNQUOTE(JSON_EXTRACT(...))`
  - `as_integer()` → `CAST(... AS INTEGER)`
  - `as_float()` → `CAST(... AS DOUBLE)`
  - `as_boolean()` → `WHEN 'true' THEN 1 WHEN 'false' THEN 0 ELSE CAST(... AS INTEGER)`

### Reflection
- `ischema_names["JSON"] = JSON` for column reflection

## Tests

**38 offline tests** in `test/test_json.py` covering DDL, path expressions, typed access, reflection mapping, and key-escaping edge cases.

**Total suite: 491 passed, 35 skipped** (no regressions).

## 4-Phase Workflow Compliance

1. **Oracle Design Review** ✅ — Validated subclassing approach, deferred vs. implement comparator decision
2. **Implementation** ✅ — Followed MySQL dialect pattern, leveraged SA defaults (no custom processors)
3. **Documentation Update** ✅ — README, CHANGELOG, ROADMAP, TYPES, FEATURE_SUPPORT, PRD
4. **Oracle Post-Implementation Review** ✅ — Caught and fixed:
   - `as_boolean()` was falling into string branch (now explicit Boolean branch)
   - `JSONIndexType`/`JSONPathType` did not escape embedded `"` in keys (now doubled per CUBRID path grammar)
