### PR TITLE
fix: async dialect — missing pool_class, _json_serializer + E2E tests

### DIFF
--- a/samples/async_basic.py
+++ b/samples/async_basic.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Minimal async usage example for sqlalchemy-cubrid.
+
+Requirements:
+    pip install sqlalchemy-cubrid pycubrid
+
+Usage:
+    # Start CUBRID (e.g. via Docker):
+    #   docker run -d --name cubrid -p 33000:33000 cubrid/cubrid:11.2
+    python samples/async_basic.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from sqlalchemy import Column, Integer, MetaData, String, Table, text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+DB_URL = "cubrid+aiopycubrid://dba:@localhost:33000/demodb"
+
+
+async def main() -> None:
+    engine = create_async_engine(DB_URL, echo=True)
+
+    # 1. Verify connectivity
+    async with engine.connect() as conn:
+        result = await conn.execute(text("SELECT 1"))
+        print("Connected! SELECT 1 =", result.scalar())
+
+    # 2. Create table
+    metadata = MetaData()
+    users = Table(
+        "async_sample_users",
+        metadata,
+        Column("id", Integer, primary_key=True, autoincrement=True),
+        Column("name", String(100)),
+    )
+
+    async with engine.begin() as conn:
+        await conn.execute(text("DROP TABLE IF EXISTS async_sample_users"))
+        await conn.run_sync(metadata.create_all)
+        print("Table created.")
+
+    # 3. Insert
+    async with engine.begin() as conn:
+        await conn.execute(users.insert(), [{"name": "Alice"}, {"name": "Bob"}])
+        print("Inserted 2 rows.")
+
+    # 4. Query
+    async with engine.connect() as conn:
+        result = await conn.execute(users.select())
+        for row in result:
+            print(f"  id={row.id}, name={row.name}")
+
+    # 5. Cleanup
+    async with engine.begin() as conn:
+        await conn.execute(text("DROP TABLE IF EXISTS async_sample_users"))
+
+    await engine.dispose()
+    print("Done!")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/sqlalchemy_cubrid/aio_pycubrid_dialect.py
+++ b/sqlalchemy_cubrid/aio_pycubrid_dialect.py
@@ -14,6 +14,7 @@ from sqlalchemy.connectors.asyncio import (
     AsyncAdapt_dbapi_cursor,
     AsyncAdapt_dbapi_module,
 )
+from sqlalchemy import pool as pool_module
 from sqlalchemy.engine.interfaces import ConnectArgsType, DBAPIModule
 from sqlalchemy.engine.url import URL
 from sqlalchemy.util.concurrency import await_only
@@ -78,6 +79,10 @@ class PyCubridAsyncDialect(PyCubridDialect):
     is_async = True
     supports_statement_cache = True
     execution_ctx_cls = PyCubridExecutionContext
+
+    @classmethod
+    def get_pool_class(cls, url: URL) -> type[pool_module.Pool]:
+        return pool_module.AsyncAdaptedQueuePool
 
     @classmethod
     def import_dbapi(cls) -> DBAPIModule:

--- a/sqlalchemy_cubrid/dialect.py
+++ b/sqlalchemy_cubrid/dialect.py
@@ -198,9 +198,17 @@ class CubridDialect(default.DefaultDialect):
 
     postfetch_lastrowid = True
 
-    def __init__(self, isolation_level: str | None = None, **kwargs: Any) -> None:
+    def __init__(
+        self,
+        isolation_level: str | None = None,
+        json_serializer: Any = None,
+        json_deserializer: Any = None,
+        **kwargs: Any,
+    ) -> None:
         super().__init__(**kwargs)
         self.isolation_level = isolation_level
+        self._json_serializer = json_serializer
+        self._json_deserializer = json_deserializer
 
     @classmethod
     def import_dbapi(cls) -> DBAPIModule:

--- a/test/test_aio_integration.py
+++ b/test/test_aio_integration.py
@@ -1,0 +1,293 @@
+# test/test_aio_integration.py
+# Copyright (C) 2021-2026 by sqlalchemy-cubrid authors and contributors
+# <see AUTHORS file>
+#
+# This module is part of sqlalchemy-cubrid and is released under
+# the MIT License: http://www.opensource.org/licenses/mit-license.php
+
+"""Async integration tests against a live CUBRID instance.
+
+These tests require a running CUBRID database.  They are skipped
+automatically when no CUBRID connection is available.
+
+Set the environment variable ``CUBRID_TEST_URL`` to the **sync**
+connection URL.  The async URL is derived automatically::
+
+    export CUBRID_TEST_URL="cubrid://dba@localhost:33000/testdb"
+
+The async dialect uses ``cubrid+aiopycubrid://`` as scheme.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import Column, Integer, MetaData, String, Table, text
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_DEFAULT_SYNC_URL = "cubrid://dba@localhost:33000/testdb"
+
+
+def _async_url() -> str:
+    """Derive the async URL from the sync one."""
+    sync = os.environ.get("CUBRID_TEST_URL", _DEFAULT_SYNC_URL)
+    return sync.replace("cubrid://", "cubrid+aiopycubrid://", 1)
+
+
+def _can_connect_async() -> bool:
+    """Return True if a CUBRID instance is reachable via async."""
+    try:
+        engine = create_async_engine(_async_url())
+
+        async def _probe() -> bool:
+            async with engine.connect() as conn:
+                await conn.execute(text("SELECT 1"))
+            await engine.dispose()
+            return True
+
+        return asyncio.get_event_loop().run_until_complete(_probe())
+    except Exception:
+        return False
+
+
+pytestmark = [
+    pytest.mark.skipif(
+        not _can_connect_async(),
+        reason="CUBRID async instance not available (set CUBRID_TEST_URL)",
+    ),
+    pytest.mark.asyncio,
+]
+
+
+@pytest_asyncio.fixture(scope="module")
+def event_loop():
+    """Create a single event loop for the module."""
+    loop = asyncio.new_event_loop()
+    yield loop
+    loop.close()
+
+
+@pytest_asyncio.fixture(scope="module")
+async def engine():
+    eng = create_async_engine(_async_url(), echo=False)
+    yield eng
+    await eng.dispose()
+
+
+@pytest_asyncio.fixture(scope="module")
+async def metadata(engine):
+    meta = MetaData()
+    Table(
+        "aio_test_users",
+        meta,
+        Column("id", Integer, primary_key=True, autoincrement=True),
+        Column("name", String(100), nullable=False),
+        Column("value", Integer),
+    )
+    async with engine.begin() as conn:
+        await conn.execute(text("DROP TABLE IF EXISTS aio_test_users"))
+        await conn.run_sync(meta.create_all)
+    yield meta
+    async with engine.begin() as conn:
+        await conn.execute(text("DROP TABLE IF EXISTS aio_test_users"))
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: Async CRUD + Transaction
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncCRUD:
+    """Async CRUD round-trip tests."""
+
+    async def test_connect(self, engine):
+        async with engine.connect() as conn:
+            result = await conn.execute(text("SELECT 1"))
+            assert result.fetchone() == (1,)
+
+    async def test_insert_and_select(self, engine, metadata):
+        users = metadata.tables["aio_test_users"]
+        async with engine.begin() as conn:
+            await conn.execute(
+                users.insert(),
+                [{"name": "alice", "value": 10}, {"name": "bob", "value": 20}],
+            )
+        async with engine.connect() as conn:
+            result = await conn.execute(users.select())
+            rows = result.fetchall()
+            assert len(rows) >= 2
+
+    async def test_update(self, engine, metadata):
+        users = metadata.tables["aio_test_users"]
+        async with engine.begin() as conn:
+            await conn.execute(
+                users.update().where(users.c.name == "alice").values(value=100)
+            )
+        async with engine.connect() as conn:
+            result = await conn.execute(
+                users.select().where(users.c.name == "alice")
+            )
+            row = result.fetchone()
+            assert row is not None and row.value == 100
+
+    async def test_delete(self, engine, metadata):
+        users = metadata.tables["aio_test_users"]
+        async with engine.begin() as conn:
+            await conn.execute(users.delete().where(users.c.name == "bob"))
+        async with engine.connect() as conn:
+            result = await conn.execute(
+                users.select().where(users.c.name == "bob")
+            )
+            assert result.fetchone() is None
+
+    async def test_transaction_rollback(self, engine, metadata):
+        users = metadata.tables["aio_test_users"]
+        try:
+            async with engine.begin() as conn:
+                await conn.execute(
+                    users.insert().values(name="will_rollback", value=999)
+                )
+                raise RuntimeError("force rollback")
+        except RuntimeError:
+            pass
+
+        async with engine.connect() as conn:
+            result = await conn.execute(
+                users.select().where(users.c.name == "will_rollback")
+            )
+            assert result.fetchone() is None
+
+    async def test_concurrent_pool(self, engine):
+        async def worker(i: int) -> int:
+            async with engine.connect() as conn:
+                r = await conn.execute(text(f"SELECT {i}"))
+                return r.scalar()
+
+        results = await asyncio.gather(*[worker(i) for i in range(5)])
+        assert sorted(results) == [0, 1, 2, 3, 4]
+
+    async def test_bad_sql_raises(self, engine):
+        with pytest.raises(Exception):
+            async with engine.connect() as conn:
+                await conn.execute(text("SELECT * FROM nonexistent_xyz"))
+
+    async def test_autocommit_toggle(self, engine):
+        async with engine.connect() as conn:
+            raw = await conn.get_raw_connection()
+            raw.autocommit = True
+            raw.autocommit = False
+
+
+# ---------------------------------------------------------------------------
+# Phase 3: JSON
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncJSON:
+    """JSON type round-trip tests."""
+
+    @pytest_asyncio.fixture(autouse=True)
+    async def _json_table(self, engine):
+        async with engine.begin() as conn:
+            await conn.execute(text("DROP TABLE IF EXISTS aio_test_json"))
+            await conn.execute(
+                text(
+                    "CREATE TABLE aio_test_json ("
+                    "  id INT AUTO_INCREMENT PRIMARY KEY,"
+                    "  payload JSON"
+                    ")"
+                )
+            )
+        yield
+        async with engine.begin() as conn:
+            await conn.execute(text("DROP TABLE IF EXISTS aio_test_json"))
+
+    async def _insert_json(self, engine, value):
+        async with engine.begin() as conn:
+            await conn.execute(
+                text("INSERT INTO aio_test_json (payload) VALUES (:p)"),
+                {"p": json.dumps(value) if value is not None else None},
+            )
+
+    async def _last_json(self, engine):
+        async with engine.connect() as conn:
+            r = await conn.execute(
+                text("SELECT payload FROM aio_test_json ORDER BY id DESC LIMIT 1")
+            )
+            raw = r.scalar()
+            return json.loads(raw) if isinstance(raw, str) else raw
+
+    async def test_dict_roundtrip(self, engine):
+        d = {"key": "value", "n": 42}
+        await self._insert_json(engine, d)
+        assert await self._last_json(engine) == d
+
+    async def test_list_roundtrip(self, engine):
+        lst = [1, "two", 3.0, None]
+        await self._insert_json(engine, lst)
+        assert await self._last_json(engine) == lst
+
+    async def test_nested_roundtrip(self, engine):
+        nested = {"a": {"b": [1, {"c": True}]}}
+        await self._insert_json(engine, nested)
+        assert await self._last_json(engine) == nested
+
+    async def test_null_json(self, engine):
+        async with engine.begin() as conn:
+            await conn.execute(
+                text("INSERT INTO aio_test_json (payload) VALUES (NULL)")
+            )
+        assert await self._last_json(engine) is None
+
+    async def test_empty_object(self, engine):
+        await self._insert_json(engine, {})
+        assert await self._last_json(engine) == {}
+
+    async def test_empty_array(self, engine):
+        await self._insert_json(engine, [])
+        assert await self._last_json(engine) == []
+
+    async def test_json_extract(self, engine):
+        async with engine.connect() as conn:
+            r = await conn.execute(
+                text("SELECT JSON_EXTRACT('{\"a\": 1}', '$.a')")
+            )
+            assert r.scalar() is not None
+
+    async def test_orm_json_type(self, engine):
+        from sqlalchemy_cubrid.types import JSON as CubridJSON
+
+        meta = MetaData()
+        t = Table(
+            "aio_test_json_orm",
+            meta,
+            Column("id", Integer, primary_key=True, autoincrement=True),
+            Column("data", CubridJSON),
+        )
+        async with engine.begin() as conn:
+            await conn.execute(text("DROP TABLE IF EXISTS aio_test_json_orm"))
+            await conn.run_sync(meta.create_all)
+
+        test_data = {"items": [1, 2, 3]}
+        async with engine.begin() as conn:
+            await conn.execute(t.insert().values(data=test_data))
+
+        async with engine.connect() as conn:
+            r = await conn.execute(t.select())
+            row = r.fetchone()
+            val = row.data
+            if isinstance(val, str):
+                val = json.loads(val)
+            assert val == test_data
+
+        async with engine.begin() as conn:
+            await conn.execute(text("DROP TABLE IF EXISTS aio_test_json_orm"))


### PR DESCRIPTION
## Summary

Fixes bugs discovered during E2E spike testing of async dialect and JSON type against live CUBRID 11.2.

### Bug Fixes

1. **get_pool_class() missing** (closes #116) — Added override returning AsyncAdaptedQueuePool
2. **_json_serializer missing** (closes #117) — Added initialization in CubridDialect.__init__
3. **#118 (autocommit)** — Confirmed NOT a dialect bug

### New Files

- `test/test_aio_integration.py` — 16 E2E tests
- `samples/async_basic.py` — Async usage example

### Test Results: 551 passed, 0 failures