### PR TITLE
fix: Alembic autogenerate false-positive diffs (#120)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,7 @@ jobs:
             test/ \
             --ignore=test/test_integration.py \
             --ignore=test/test_suite.py \
+            --ignore=test/test_aio_integration.py \
             -v --tb=short \
             --cov=sqlalchemy_cubrid \
             --cov-report=term-missing \

--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,4 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+.sisyphus/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.2] - 2026-04-19
+
+### Fixed
+
+- **Alembic autogenerate false-positive diffs** (#120):
+  - `get_indexes()` now filters out the implicit indexes that CUBRID auto-creates
+    for every primary-key and foreign-key constraint.  These auto-indexes
+    previously caused Alembic to emit spurious `op.drop_index` /
+    `op.create_index` operations on every `alembic check` / `revision --autogenerate`
+    run.  The dialect now batch-queries `_db_index.is_primary_key` and
+    `_db_index.is_foreign_key` (single round trip) and excludes flagged indexes
+    from the reflection result.
+  - `get_foreign_keys()` rewritten to parse `SHOW CREATE TABLE` output.  The
+    previous implementation queried the `db_constraint` view, which is **not**
+    queryable in CUBRID 11.x (despite older docs referencing it) and silently
+    returned an empty list — leaving Alembic blind to every existing FK and
+    causing it to schedule recreation on every run.
+  - `get_unique_constraints()` rewritten to parse `SHOW CREATE TABLE` output
+    for the same reason as `get_foreign_keys()`.
+- **`compare_type` for unbounded VARCHAR**: `CubridImpl.compare_type()` now
+  treats CUBRID's `VARCHAR(1073741823)` (the physical storage for `STRING`,
+  `CLOB`, `TEXT`, and `String` without a length) as equivalent to SQLAlchemy's
+  `Text()`, `CLOB()`, and `String()` (no length), eliminating false-positive
+  type-change diffs in Alembic autogenerate.
+
 ## [1.2.1] - 2026-04-19
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ test: ## Run offline tests with coverage (no DB required)
 	$(PYTEST) $(TESTS)/ -v \
 		--ignore=$(TESTS)/test_integration.py \
 		--ignore=$(TESTS)/test_suite.py \
+		--ignore=$(TESTS)/test_aio_integration.py \
 		--cov=$(SRC) \
 		--cov-report=term-missing \
 		--cov-fail-under=95

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ cubrid = [
 dev = [
     "pytest>=7.0",
     "pytest-cov",
+    "pytest-asyncio",
     "ruff==0.15.8",
     "mypy==1.19.1",
     "bandit[toml]==1.9.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sqlalchemy-cubrid"
-version = "1.2.1"
+version = "1.2.2"
 description = "CUBRID dialect for SQLAlchemy"
 readme = "README.md"
 license = "MIT"

--- a/sqlalchemy_cubrid/__init__.py
+++ b/sqlalchemy_cubrid/__init__.py
@@ -52,7 +52,7 @@ from sqlalchemy.sql.sqltypes import (
     TIMESTAMP,
 )
 
-__version__ = "1.2.1"
+__version__ = "1.2.2"
 
 __all__ = (
     "insert",

--- a/sqlalchemy_cubrid/alembic_impl.py
+++ b/sqlalchemy_cubrid/alembic_impl.py
@@ -76,6 +76,15 @@ class CubridImpl(DefaultImpl):
 
     _collection_type_names: set[str] = {"SET", "MULTISET", "SEQUENCE"}
 
+    # CUBRID's STRING / CLOB / Text are stored physically as
+    # VARCHAR(1073741823).  When SQLAlchemy's reflection round-trips a
+    # ``Text`` / ``CLOB`` / ``STRING`` column it sees a VARCHAR with that
+    # exact length, which trips Alembic's default compare_type into
+    # reporting a spurious type change on every autogenerate run
+    # (see cubrid-labs/sqlalchemy-cubrid#120).
+    _CUBRID_UNBOUNDED_VARCHAR_LENGTH: int = 1073741823
+    _unbounded_string_type_names: set[str] = {"TEXT", "CLOB", "STRING"}
+
     @staticmethod
     def _normalize_collection_value(value: object) -> str:
         if isinstance(value, str):
@@ -115,6 +124,11 @@ class CubridImpl(DefaultImpl):
         inspector_type = inspector_column.type
         metadata_type = metadata_column.type
 
+        # Suppress false-positive Text/CLOB/STRING vs VARCHAR(max) diffs.
+        # See ``_CUBRID_UNBOUNDED_VARCHAR_LENGTH`` docstring above.
+        if self._is_unbounded_string_match(inspector_type, metadata_type):
+            return False
+
         inspector_name = inspector_type.__class__.__name__
         metadata_name = metadata_type.__class__.__name__
 
@@ -143,3 +157,29 @@ class CubridImpl(DefaultImpl):
             return inspector_values != metadata_values
 
         return set(inspector_values) != set(metadata_values)
+
+    @classmethod
+    def _is_unbounded_string_match(
+        cls, inspector_type: TypeEngine[Any], metadata_type: TypeEngine[Any]
+    ) -> bool:
+        """Return ``True`` when one side is an unbounded string type and the other is a VARCHAR sized to CUBRID's STRING maximum length."""
+        return cls._matches_unbounded_pair(
+            inspector_type, metadata_type
+        ) or cls._matches_unbounded_pair(metadata_type, inspector_type)
+
+    @classmethod
+    def _matches_unbounded_pair(
+        cls, varchar_side: TypeEngine[Any], unbounded_side: TypeEngine[Any]
+    ) -> bool:
+        if varchar_side.__class__.__name__ != "VARCHAR":
+            return False
+        if getattr(varchar_side, "length", None) != cls._CUBRID_UNBOUNDED_VARCHAR_LENGTH:
+            return False
+        unbounded_name = unbounded_side.__class__.__name__.upper()
+        if unbounded_name in cls._unbounded_string_type_names:
+            return True
+        # Plain SQLAlchemy String() with no length declared also maps to
+        # VARCHAR(1073741823) on CUBRID.
+        if unbounded_name == "STRING" or unbounded_name.endswith("STRING"):
+            return getattr(unbounded_side, "length", None) is None
+        return False

--- a/sqlalchemy_cubrid/dialect.py
+++ b/sqlalchemy_cubrid/dialect.py
@@ -78,6 +78,29 @@ _RE_TYPE_PARAMS = re.compile(r"\([\d,]+\)")
 _RE_LENGTH = re.compile(r"\((\d+)\)")
 _RE_PRECISION_SCALE = re.compile(r"\((\d+)(?:,\s*(\d+))?\)")
 
+# CUBRID's ``SHOW CREATE TABLE`` emits foreign-key clauses such as::
+#
+#     CONSTRAINT [fk_name] FOREIGN KEY ([col1], [col2]) REFERENCES
+#         [owner.ref_table] ([rcol1], [rcol2]) ON DELETE ... ON UPDATE ...
+#
+# We parse this DDL fragment because CUBRID exposes no queryable view that
+# carries the referenced table/columns alongside the constraint name.
+_RE_FOREIGN_KEY = re.compile(
+    r"CONSTRAINT\s+\[(?P<name>[^\]]+)\]\s+FOREIGN\s+KEY\s*"
+    r"\((?P<cols>[^)]+)\)\s+REFERENCES\s+"
+    r"\[(?P<ref_table>[^\]]+)\]\s*\((?P<ref_cols>[^)]+)\)",
+    re.IGNORECASE,
+)
+# Parses ``CONSTRAINT [name] UNIQUE KEY ([col1], [col2])`` from
+# ``SHOW CREATE TABLE`` output.  Same rationale as ``_RE_FOREIGN_KEY`` —
+# CUBRID's ``db_constraint`` view is not queryable in 11.x.
+_RE_UNIQUE_KEY = re.compile(
+    r"CONSTRAINT\s+\[(?P<name>[^\]]+)\]\s+UNIQUE\s+KEY\s*"
+    r"\((?P<cols>[^)]+)\)",
+    re.IGNORECASE,
+)
+_RE_BRACKET_IDENT = re.compile(r"\[([^\]]+)\]")
+
 
 # -----------------------------------------------------------------------
 # Column-spec and ischema_names mappings
@@ -374,45 +397,45 @@ class CubridDialect(default.DefaultDialect):
     ) -> list[ReflectedForeignKeyConstraint]:
         """Return foreign key information for *table_name*.
 
-        Uses ``db_constraint`` system table to retrieve FK constraints.
+        Parses ``SHOW CREATE TABLE`` output to extract FK constraints.
+        CUBRID exposes no queryable ``db_constraint`` view (despite older
+        documentation referencing it), so the DDL string is the only
+        reliable source for FK metadata that includes the referenced table
+        and columns. See cubrid-labs/sqlalchemy-cubrid#120.
         """
         foreign_keys: list[ReflectedForeignKeyConstraint] = []
         try:
-            result = connection.execute(
-                text(
-                    "SELECT c.constraint_name, c.class_name, "
-                    "a.attr_name, c.ref_class_name, ra.attr_name "
-                    "FROM db_constraint c "
-                    "JOIN _db_index_key a ON c.index_name = a.index_name "
-                    "LEFT JOIN db_constraint rc ON c.ref_class_name = rc.class_name "
-                    "  AND rc.type = 0 "
-                    "LEFT JOIN _db_index_key ra ON rc.index_name = ra.index_name "
-                    "  AND a.key_order = ra.key_order "
-                    "WHERE c.class_name = :table AND c.type = 3 "
-                    "ORDER BY c.constraint_name, a.key_order"
-                ),
-                {"table": table_name},
+            quoted = self.identifier_preparer.quote_identifier(table_name)
+            result = connection.execute(text(f"SHOW CREATE TABLE {quoted}"))
+            row = result.fetchone()
+        except Exception:  # nosec B110 — graceful fallback when DDL unavailable
+            return foreign_keys
+        if row is None:
+            return foreign_keys
+        ddl = str(row[1]) if len(row) > 1 else str(row[0])
+        for fk_match in _RE_FOREIGN_KEY.finditer(ddl):
+            constraint_name = fk_match.group("name")
+            constrained_columns = [
+                col.strip()
+                for col in _RE_BRACKET_IDENT.findall(fk_match.group("cols"))
+            ]
+            ref_table_raw = fk_match.group("ref_table")
+            # CUBRID prefixes referenced tables with the owner (e.g.
+            # ``dba.budget_categories``) — strip it for SQLAlchemy.
+            ref_table = ref_table_raw.split(".", 1)[-1]
+            referred_columns = [
+                col.strip()
+                for col in _RE_BRACKET_IDENT.findall(fk_match.group("ref_cols"))
+            ]
+            foreign_keys.append(
+                {
+                    "name": constraint_name,
+                    "constrained_columns": constrained_columns,
+                    "referred_schema": schema,
+                    "referred_table": ref_table,
+                    "referred_columns": referred_columns,
+                }
             )
-
-            fk_dict: dict[str, ReflectedForeignKeyConstraint] = {}
-            for row in result:
-                name = row[0]
-                if name not in fk_dict:
-                    fk_dict[name] = {
-                        "name": name,
-                        "constrained_columns": [],
-                        "referred_schema": schema,
-                        "referred_table": row[3],
-                        "referred_columns": [],
-                    }
-                fk_dict[name]["constrained_columns"].append(row[2])
-                if row[4]:
-                    fk_dict[name]["referred_columns"].append(row[4])
-
-            foreign_keys = list(fk_dict.values())
-        except Exception:  # nosec B110 — graceful fallback when FK info unavailable
-            pass
-
         return foreign_keys
 
     @reflection.cache
@@ -469,31 +492,43 @@ class CubridDialect(default.DefaultDialect):
         """Return index information for *table_name*."""
         idict: dict[str, ReflectedIndex] = {}
 
-        # Batch-fetch primary key flags for all indexes on this table
-        # instead of issuing one query per index (N+1 → 1+1).
+        # Batch-fetch primary-key and foreign-key flags for all indexes on
+        # this table from CUBRID's ``_db_index`` catalog (single query for
+        # both, instead of N+1 lookups).
+        #
+        # PK indexes are filtered because SQLAlchemy reports the PK via
+        # ``get_pk_constraint`` separately.  FK indexes are filtered because
+        # CUBRID auto-creates an index for every foreign key (with the same
+        # name as the FK constraint) and these are an implementation detail
+        # — if reported they cause Alembic autogenerate to emit spurious
+        # ``op.drop_index`` / ``op.create_index`` diffs on every run.
+        # See cubrid-labs/sqlalchemy-cubrid#120.
         pk_indexes: set[str] = set()
+        fk_indexes: set[str] = set()
         try:
-            pk_result = connection.execute(
+            flag_result = connection.execute(
                 text(
-                    "SELECT index_name, is_primary_key FROM _db_index "
-                    "WHERE class_of.class_name = :table"
+                    "SELECT index_name, is_primary_key, is_foreign_key "
+                    "FROM _db_index WHERE class_of.class_name = :table"
                 ),
                 {"table": table_name},
             )
-            for pk_row in pk_result:
-                if pk_row[1]:
-                    pk_indexes.add(pk_row[0])
+            for flag_row in flag_result:
+                if flag_row[1]:
+                    pk_indexes.add(flag_row[0])
+                if flag_row[2]:
+                    fk_indexes.add(flag_row[0])
         except Exception:
-            # Fallback: if catalog query fails, pk_indexes stays empty
-            # so no indexes will be wrongly excluded.
-            log.debug("Batch PK query failed for table %s, falling back", table_name)
+            # Fallback: if the catalog query fails, both sets stay empty so
+            # no indexes will be wrongly excluded.
+            log.debug("Batch index-flag query failed for table %s, falling back", table_name)
 
         quoted = self.identifier_preparer.quote_identifier(table_name)
         result = connection.execute(text(f"SHOW INDEXES IN {quoted}"))
         for row in result:
             index_name = row[2]
 
-            if index_name not in pk_indexes:
+            if index_name not in pk_indexes and index_name not in fk_indexes:
                 if index_name in idict:
                     idict[index_name]["column_names"].append(row[4])
                 else:
@@ -516,25 +551,23 @@ class CubridDialect(default.DefaultDialect):
         """Return unique constraints for *table_name*."""
         unique_constraints: list[ReflectedUniqueConstraint] = []
         try:
-            result = connection.execute(
-                text(
-                    "SELECT c.constraint_name, a.attr_name "
-                    "FROM db_constraint c "
-                    "JOIN _db_index_key a ON c.index_name = a.index_name "
-                    "WHERE c.class_name = :table AND c.type = 1 "
-                    "ORDER BY c.constraint_name, a.key_order"
-                ),
-                {"table": table_name},
+            quoted = self.identifier_preparer.quote_identifier(table_name)
+            result = connection.execute(text(f"SHOW CREATE TABLE {quoted}"))
+            row = result.fetchone()
+        except Exception:  # nosec B110 — graceful fallback when DDL unavailable
+            return unique_constraints
+        if row is None:
+            return unique_constraints
+        ddl = str(row[1]) if len(row) > 1 else str(row[0])
+        for uc_match in _RE_UNIQUE_KEY.finditer(ddl):
+            constraint_name = uc_match.group("name")
+            column_names = [
+                col.strip()
+                for col in _RE_BRACKET_IDENT.findall(uc_match.group("cols"))
+            ]
+            unique_constraints.append(
+                {"name": constraint_name, "column_names": column_names}
             )
-            uc_dict: dict[str, ReflectedUniqueConstraint] = {}
-            for row in result:
-                name = row[0]
-                if name not in uc_dict:
-                    uc_dict[name] = {"name": name, "column_names": []}
-                uc_dict[name]["column_names"].append(row[1])
-            unique_constraints = list(uc_dict.values())
-        except Exception:  # nosec B110 — graceful fallback when UC info unavailable
-            pass
         return unique_constraints
 
     @reflection.cache

--- a/sqlalchemy_cubrid/dialect.py
+++ b/sqlalchemy_cubrid/dialect.py
@@ -416,16 +416,14 @@ class CubridDialect(default.DefaultDialect):
         for fk_match in _RE_FOREIGN_KEY.finditer(ddl):
             constraint_name = fk_match.group("name")
             constrained_columns = [
-                col.strip()
-                for col in _RE_BRACKET_IDENT.findall(fk_match.group("cols"))
+                col.strip() for col in _RE_BRACKET_IDENT.findall(fk_match.group("cols"))
             ]
             ref_table_raw = fk_match.group("ref_table")
             # CUBRID prefixes referenced tables with the owner (e.g.
             # ``dba.budget_categories``) — strip it for SQLAlchemy.
             ref_table = ref_table_raw.split(".", 1)[-1]
             referred_columns = [
-                col.strip()
-                for col in _RE_BRACKET_IDENT.findall(fk_match.group("ref_cols"))
+                col.strip() for col in _RE_BRACKET_IDENT.findall(fk_match.group("ref_cols"))
             ]
             foreign_keys.append(
                 {
@@ -562,12 +560,9 @@ class CubridDialect(default.DefaultDialect):
         for uc_match in _RE_UNIQUE_KEY.finditer(ddl):
             constraint_name = uc_match.group("name")
             column_names = [
-                col.strip()
-                for col in _RE_BRACKET_IDENT.findall(uc_match.group("cols"))
+                col.strip() for col in _RE_BRACKET_IDENT.findall(uc_match.group("cols"))
             ]
-            unique_constraints.append(
-                {"name": constraint_name, "column_names": column_names}
-            )
+            unique_constraints.append({"name": constraint_name, "column_names": column_names})
         return unique_constraints
 
     @reflection.cache

--- a/test/test_aio_integration.py
+++ b/test/test_aio_integration.py
@@ -27,8 +27,7 @@ import os
 import pytest
 import pytest_asyncio
 from sqlalchemy import Column, Integer, MetaData, String, Table, text
-from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.ext.asyncio import create_async_engine
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -129,13 +128,9 @@ class TestAsyncCRUD:
     async def test_update(self, engine, metadata):
         users = metadata.tables["aio_test_users"]
         async with engine.begin() as conn:
-            await conn.execute(
-                users.update().where(users.c.name == "alice").values(value=100)
-            )
+            await conn.execute(users.update().where(users.c.name == "alice").values(value=100))
         async with engine.connect() as conn:
-            result = await conn.execute(
-                users.select().where(users.c.name == "alice")
-            )
+            result = await conn.execute(users.select().where(users.c.name == "alice"))
             row = result.fetchone()
             assert row is not None and row.value == 100
 
@@ -144,26 +139,20 @@ class TestAsyncCRUD:
         async with engine.begin() as conn:
             await conn.execute(users.delete().where(users.c.name == "bob"))
         async with engine.connect() as conn:
-            result = await conn.execute(
-                users.select().where(users.c.name == "bob")
-            )
+            result = await conn.execute(users.select().where(users.c.name == "bob"))
             assert result.fetchone() is None
 
     async def test_transaction_rollback(self, engine, metadata):
         users = metadata.tables["aio_test_users"]
         try:
             async with engine.begin() as conn:
-                await conn.execute(
-                    users.insert().values(name="will_rollback", value=999)
-                )
+                await conn.execute(users.insert().values(name="will_rollback", value=999))
                 raise RuntimeError("force rollback")
         except RuntimeError:
             pass
 
         async with engine.connect() as conn:
-            result = await conn.execute(
-                users.select().where(users.c.name == "will_rollback")
-            )
+            result = await conn.execute(users.select().where(users.c.name == "will_rollback"))
             assert result.fetchone() is None
 
     async def test_concurrent_pool(self, engine):
@@ -243,9 +232,7 @@ class TestAsyncJSON:
 
     async def test_null_json(self, engine):
         async with engine.begin() as conn:
-            await conn.execute(
-                text("INSERT INTO aio_test_json (payload) VALUES (NULL)")
-            )
+            await conn.execute(text("INSERT INTO aio_test_json (payload) VALUES (NULL)"))
         assert await self._last_json(engine) is None
 
     async def test_empty_object(self, engine):
@@ -258,9 +245,7 @@ class TestAsyncJSON:
 
     async def test_json_extract(self, engine):
         async with engine.connect() as conn:
-            r = await conn.execute(
-                text("SELECT JSON_EXTRACT('{\"a\": 1}', '$.a')")
-            )
+            r = await conn.execute(text("SELECT JSON_EXTRACT('{\"a\": 1}', '$.a')"))
             assert r.scalar() is not None
 
     async def test_orm_json_type(self, engine):

--- a/test/test_alembic.py
+++ b/test/test_alembic.py
@@ -259,3 +259,43 @@ class TestCubridImplAutogenerate:
         metadata_column = sa.Column("v", cubrid_types.MULTISET("a", "b"))
 
         assert impl.compare_type(inspector_column, metadata_column) is True
+
+    def test_compare_type_text_vs_varchar_max_no_diff(self):
+        """Text() vs VARCHAR(1073741823) must NOT be reported as a type change.
+
+        See cubrid-labs/sqlalchemy-cubrid#120 — CUBRID stores Text/CLOB/STRING
+        as VARCHAR(1073741823) so reflection round-trips trip Alembic's
+        default compare_type.
+        """
+        from sqlalchemy_cubrid.alembic_impl import CubridImpl
+
+        impl = object.__new__(CubridImpl)
+        inspector_column = sa.Column("v", cubrid_types.VARCHAR(1073741823))
+        for metadata_type in (sa.Text(), cubrid_types.CLOB(), cubrid_types.STRING()):
+            metadata_column = sa.Column("v", metadata_type)
+            assert impl.compare_type(inspector_column, metadata_column) is False
+            # Reverse direction must also hold.
+            assert impl.compare_type(metadata_column, inspector_column) is False
+
+    def test_compare_type_varchar_max_vs_string_no_length_no_diff(self):
+        """Plain String() (no length) maps to VARCHAR(max) on CUBRID."""
+        from sqlalchemy_cubrid.alembic_impl import CubridImpl
+
+        impl = object.__new__(CubridImpl)
+        inspector_column = sa.Column("v", cubrid_types.VARCHAR(1073741823))
+        metadata_column = sa.Column("v", sa.String())
+        assert impl.compare_type(inspector_column, metadata_column) is False
+
+    def test_compare_type_varchar_bounded_still_compared(self):
+        """VARCHAR(100) vs Text() must still be detected as a real diff."""
+        from alembic.ddl.impl import DefaultImpl
+
+        from sqlalchemy_cubrid.alembic_impl import CubridImpl
+
+        impl = object.__new__(CubridImpl)
+        inspector_column = sa.Column("v", cubrid_types.VARCHAR(100))
+        metadata_column = sa.Column("v", sa.Text())
+        with mock.patch.object(DefaultImpl, "compare_type", return_value=True) as m:
+            result = impl.compare_type(inspector_column, metadata_column)
+        assert result is True
+        m.assert_called_once()

--- a/test/test_dialect_offline.py
+++ b/test/test_dialect_offline.py
@@ -449,8 +449,8 @@ class TestReflectionMethods:
         ]
 
         connection.execute.side_effect = [
-            flag_rows,         # batch _db_index query
-            show_indexes_rows, # SHOW INDEXES
+            flag_rows,  # batch _db_index query
+            show_indexes_rows,  # SHOW INDEXES
         ]
 
         indexes = _invoke_reflection(dialect, "get_indexes", connection, "users")
@@ -474,7 +474,7 @@ class TestReflectionMethods:
 
         connection.execute.side_effect = [
             RuntimeError("catalog unavailable"),  # batch flag query fails
-            show_indexes_rows,                    # SHOW INDEXES
+            show_indexes_rows,  # SHOW INDEXES
         ]
 
         indexes = _invoke_reflection(dialect, "get_indexes", connection, "users")

--- a/test/test_dialect_offline.py
+++ b/test/test_dialect_offline.py
@@ -338,14 +338,24 @@ class TestReflectionMethods:
     def test_get_foreign_keys_success_and_exception(self):
         dialect = CubridDialect()
 
+        ddl = (
+            "CREATE TABLE [orders] (\n"
+            "  [id] INTEGER NOT NULL,\n"
+            "  CONSTRAINT [pk_orders] PRIMARY KEY ([id]),\n"
+            "  CONSTRAINT [fk_order_user] FOREIGN KEY ([user_id], [tenant_id]) "
+            "REFERENCES [dba.users] ([id], [tenant_id]) "
+            "ON DELETE RESTRICT ON UPDATE RESTRICT,\n"
+            "  CONSTRAINT [fk_order_legacy] FOREIGN KEY ([legacy_id]) "
+            "REFERENCES [legacy] ([id])\n"
+            ")"
+        )
+
         success_conn = MagicMock()
         success_conn.info_cache = {}
         success_conn.dialect_options = {}
-        success_conn.execute.return_value = [
-            ("fk_order_user", "orders", "user_id", "users", "id"),
-            ("fk_order_user", "orders", "tenant_id", "users", "tenant_id"),
-            ("fk_no_ref_col", "orders", "legacy_id", "legacy", None),
-        ]
+        success_result = MagicMock()
+        success_result.fetchone.return_value = ("orders", ddl)
+        success_conn.execute.return_value = success_result
 
         fks = _invoke_reflection(
             dialect,
@@ -358,12 +368,14 @@ class TestReflectionMethods:
         assert len(fks) == 2
         first = next(item for item in fks if item["name"] == "fk_order_user")
         assert first["constrained_columns"] == ["user_id", "tenant_id"]
+        # Owner prefix (``dba.``) must be stripped from the referenced table.
         assert first["referred_table"] == "users"
         assert first["referred_columns"] == ["id", "tenant_id"]
         assert first["referred_schema"] == "main"
 
-        second = next(item for item in fks if item["name"] == "fk_no_ref_col")
-        assert second["referred_columns"] == []
+        second = next(item for item in fks if item["name"] == "fk_order_legacy")
+        assert second["referred_table"] == "legacy"
+        assert second["referred_columns"] == ["id"]
 
         failed_conn = MagicMock()
         failed_conn.info_cache = {}
@@ -420,11 +432,13 @@ class TestReflectionMethods:
         connection.info_cache = {}
         connection.dialect_options = {}
 
-        # Batch PK query returns index_name, is_primary_key pairs
-        pk_batch_result = [
-            ("uq_name", 0),
-            ("pk_users", 1),
-            ("idx_email", 0),
+        # Single batch query returns (index_name, is_primary_key, is_foreign_key)
+        # tuples for every index on the table.  PK and FK auto-indexes are
+        # filtered from the SHOW INDEXES output.
+        flag_rows = [
+            ("uq_name", 0, 0),
+            ("pk_users", 1, 0),
+            ("idx_email", 0, 0),
         ]
 
         show_indexes_rows = [
@@ -435,8 +449,8 @@ class TestReflectionMethods:
         ]
 
         connection.execute.side_effect = [
-            pk_batch_result,  # batch PK query
-            show_indexes_rows,  # SHOW INDEXES
+            flag_rows,         # batch _db_index query
+            show_indexes_rows, # SHOW INDEXES
         ]
 
         indexes = _invoke_reflection(dialect, "get_indexes", connection, "users")
@@ -447,7 +461,7 @@ class TestReflectionMethods:
         ]
 
     def test_get_indexes_batch_pk_query_failure(self):
-        """When the batch PK catalog query fails, all indexes are returned."""
+        """When the batch catalog query fails, all indexes are returned."""
         dialect = CubridDialect()
         connection = MagicMock()
         connection.info_cache = {}
@@ -459,28 +473,67 @@ class TestReflectionMethods:
         ]
 
         connection.execute.side_effect = [
-            RuntimeError("catalog unavailable"),  # batch PK query fails
-            show_indexes_rows,  # SHOW INDEXES
+            RuntimeError("catalog unavailable"),  # batch flag query fails
+            show_indexes_rows,                    # SHOW INDEXES
         ]
 
         indexes = _invoke_reflection(dialect, "get_indexes", connection, "users")
 
-        # Both indexes returned since PK detection failed gracefully
+        # Both indexes returned since PK/FK detection failed gracefully.
         assert len(indexes) == 2
         assert indexes[0]["name"] == "uq_name"
         assert indexes[1]["name"] == "pk_users"
 
+    def test_get_indexes_excludes_fk_auto_indexes(self):
+        """FK auto-indexes (``_db_index.is_foreign_key`` true) are filtered.
+
+        See cubrid-labs/sqlalchemy-cubrid#120 — otherwise Alembic
+        autogenerate emits spurious drop_index/create_index diffs.
+        """
+        dialect = CubridDialect()
+        connection = MagicMock()
+        connection.info_cache = {}
+        connection.dialect_options = {}
+
+        flag_rows = [
+            ("fk_orders_user", 0, 1),
+            ("fk_orders_product", 0, 1),
+            ("idx_orders_status", 0, 0),
+        ]
+
+        connection.execute.side_effect = [
+            flag_rows,
+            [
+                (None, 1, "fk_orders_user", None, "user_id"),
+                (None, 1, "fk_orders_product", None, "product_id"),
+                (None, 1, "idx_orders_status", None, "status"),
+            ],
+        ]
+
+        indexes = _invoke_reflection(dialect, "get_indexes", connection, "orders")
+
+        assert indexes == [
+            {"name": "idx_orders_status", "column_names": ["status"], "unique": False},
+        ]
+
     def test_get_unique_constraints_success_and_exception(self):
         dialect = CubridDialect()
+
+        ddl = (
+            "CREATE TABLE [users] (\n"
+            "  [id] INTEGER NOT NULL,\n"
+            "  CONSTRAINT [pk_users] PRIMARY KEY ([id]),\n"
+            "  CONSTRAINT [uq_users_email] UNIQUE KEY ([email], [tenant_id]),\n"
+            "  CONSTRAINT [uq_users_name] UNIQUE KEY ([name])\n"
+            ")"
+        )
 
         success_conn = MagicMock()
         success_conn.info_cache = {}
         success_conn.dialect_options = {}
-        success_conn.execute.return_value = [
-            ("uq_users_email", "email"),
-            ("uq_users_email", "tenant_id"),
-            ("uq_users_name", "name"),
-        ]
+        success_result = MagicMock()
+        success_result.fetchone.return_value = ("users", ddl)
+        success_conn.execute.return_value = success_result
 
         unique_constraints = _invoke_reflection(
             dialect,


### PR DESCRIPTION
## Summary

Fixes #120 — three reflection bugs and one type-comparison bug that caused
`alembic check` / `alembic revision --autogenerate` to emit spurious diffs
on every run against a CUBRID database.

## Changes

### `dialect.py`

1. **`get_indexes()`** — now filters out the implicit indexes that CUBRID
   auto-creates for every `PRIMARY KEY` and `FOREIGN KEY` constraint.
   These auto-indexes share the constraint name and previously appeared
   in the reflection result, causing Alembic to schedule `op.drop_index`
   / `op.create_index` on every run.  Implementation batch-queries
   `_db_index.is_primary_key` and `_db_index.is_foreign_key` in a single
   round trip.

2. **`get_foreign_keys()`** — rewritten to parse `SHOW CREATE TABLE`
   output.  The previous implementation queried the `db_constraint` view,
   which is **not queryable** in CUBRID 11.x (despite older docs
   referencing it):

       Unknown class "dba.db_constraint"

   The bare `except Exception` masked this and returned `[]`, leaving
   Alembic blind to every existing FK and scheduling them for recreation.
   The new parser strips the owner prefix (e.g. `dba.`) from the
   referenced table name.

3. **`get_unique_constraints()`** — same broken `db_constraint` query
   pattern, also rewritten to parse `SHOW CREATE TABLE` output.

### `alembic_impl.py`

4. **`CubridImpl.compare_type()`** — now treats CUBRID's
   `VARCHAR(1073741823)` (the physical storage for `STRING`, `CLOB`,
   `TEXT`, and unbounded `String`) as equivalent to SQLAlchemy `Text()`,
   `CLOB()`, and `String()` (no length).  Eliminates false-positive
   type-change diffs in autogenerate.

## Verification

- 504 offline tests pass (added 3 compare_type tests + rewrote 4 reflection
  tests for the new parsing logic).
- Verified live against CUBRID 11.2: `alembic check` now reports
  `No new upgrade operations detected.` for the `our-tax` project
  (previously emitted dozens of spurious FK index drop/create + Text
  type-change operations).
- Live reflection probe confirms `get_foreign_keys()`,
  `get_unique_constraints()`, and `get_indexes()` all return correct
  metadata (FKs no longer empty, FK auto-indexes filtered).

## Release

Bumps version to **1.2.2** and adds CHANGELOG entry.

Closes #120