### PR TITLE
test+refactor: expand golden/Alembic tests, extract merge validation

### DIFF
--- a/sqlalchemy_cubrid/compiler.py
+++ b/sqlalchemy_cubrid/compiler.py
@@ -230,26 +230,33 @@ class CubridCompiler(compiler.SQLCompiler):
 
         return f"ON DUPLICATE KEY UPDATE {', '.join(clauses)}"
 
+    def _validate_merge_params(self, merge_stmt: Any) -> None:
+        """Validate MERGE statement has required components."""
+        from sqlalchemy import exc
+
+        if merge_stmt._target is None:
+            raise exc.CompileError("MERGE statement requires a target table")
+        if merge_stmt._using_source is None:
+            raise exc.CompileError("MERGE statement requires a USING source")
+        if merge_stmt._on_condition is None:
+            raise exc.CompileError("MERGE statement requires an ON condition")
+        if merge_stmt._when_matched is None and merge_stmt._when_not_matched is None:
+            raise exc.CompileError(
+                "MERGE statement must include WHEN MATCHED and/or WHEN NOT MATCHED"
+            )
+
+
     def visit_merge(self, merge_stmt: Any, **kw: Any) -> str:
         from sqlalchemy import exc
         from sqlalchemy.sql import elements
+
+        self._validate_merge_params(merge_stmt)
 
         target = merge_stmt._target
         source = merge_stmt._using_source
         on_condition = merge_stmt._on_condition
         when_matched = merge_stmt._when_matched
         when_not_matched = merge_stmt._when_not_matched
-
-        if target is None:
-            raise exc.CompileError("MERGE statement requires a target table")
-        if source is None:
-            raise exc.CompileError("MERGE statement requires a USING source")
-        if on_condition is None:
-            raise exc.CompileError("MERGE statement requires an ON condition")
-        if when_matched is None and when_not_matched is None:
-            raise exc.CompileError(
-                "MERGE statement must include WHEN MATCHED and/or WHEN NOT MATCHED"
-            )
 
         target_columns = getattr(target, "c", None)
 

--- a/test/test_alembic_roundtrip.py
+++ b/test/test_alembic_roundtrip.py
@@ -200,3 +200,99 @@ def test_create_reflect_compare_roundtrip_no_diffs() -> None:
         context = MigrationContext.configure(connection=connection, opts={"compare_type": True})
         assert compare_metadata(context, metadata) == []
         assert compare_metadata(context, metadata) == []
+
+
+def test_roundtrip_composite_pk_multi_fk_defaults_no_diffs() -> None:
+    """Complex schema: composite PK, multiple FKs, multi-col unique, defaults."""
+    import sqlalchemy_cubrid.alembic_impl  # noqa: F401
+
+    metadata = sa.MetaData()
+
+    sa.Table(
+        "departments",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("name", VARCHAR(100), nullable=False),
+    )
+
+    sa.Table(
+        "employees",
+        metadata,
+        sa.Column("dept_id", sa.Integer, nullable=False),
+        sa.Column("emp_id", sa.Integer, nullable=False),
+        sa.Column("name", VARCHAR(200), nullable=False),
+        sa.Column("manager_dept_id", sa.Integer, nullable=True),
+        sa.Column("manager_emp_id", sa.Integer, nullable=True),
+        sa.Column("salary", sa.Numeric(12, 2), server_default="0.00"),
+        sa.PrimaryKeyConstraint("dept_id", "emp_id"),
+        sa.ForeignKeyConstraint(
+            ["dept_id"], ["departments.id"], name="fk_emp_dept"
+        ),
+        sa.ForeignKeyConstraint(
+            ["manager_dept_id", "manager_emp_id"],
+            ["employees.dept_id", "employees.emp_id"],
+            name="fk_emp_manager",
+        ),
+        sa.UniqueConstraint("dept_id", "name", name="uq_emp_dept_name"),
+    )
+
+    reflected_schema = {
+        "departments": {
+            "columns": [
+                {"name": "id", "type": sa.Integer(), "nullable": False},
+                {"name": "name", "type": VARCHAR(100), "nullable": False},
+            ],
+            "pk_constraint": {"name": None, "constrained_columns": ["id"]},
+        },
+        "employees": {
+            "columns": [
+                {"name": "dept_id", "type": sa.Integer(), "nullable": False},
+                {"name": "emp_id", "type": sa.Integer(), "nullable": False},
+                {"name": "name", "type": VARCHAR(200), "nullable": False},
+                {"name": "manager_dept_id", "type": sa.Integer(), "nullable": True},
+                {"name": "manager_emp_id", "type": sa.Integer(), "nullable": True},
+                {
+                    "name": "salary",
+                    "type": sa.Numeric(12, 2),
+                    "nullable": True,
+                    "default": "0.00",
+                },
+            ],
+            "pk_constraint": {
+                "name": None,
+                "constrained_columns": ["dept_id", "emp_id"],
+            },
+            "foreign_keys": [
+                {
+                    "name": "fk_emp_dept",
+                    "constrained_columns": ["dept_id"],
+                    "referred_schema": None,
+                    "referred_table": "departments",
+                    "referred_columns": ["id"],
+                    "options": {},
+                },
+                {
+                    "name": "fk_emp_manager",
+                    "constrained_columns": ["manager_dept_id", "manager_emp_id"],
+                    "referred_schema": None,
+                    "referred_table": "employees",
+                    "referred_columns": ["dept_id", "emp_id"],
+                    "options": {},
+                },
+            ],
+            "unique_constraints": [
+                {"name": "uq_emp_dept_name", "column_names": ["dept_id", "name"]},
+            ],
+        },
+    }
+
+    connection = _make_connection()
+    inspector = _MockInspector(connection, reflected_schema)
+
+    with (
+        mock.patch("alembic.autogenerate.api.inspect", return_value=inspector),
+        mock.patch("alembic.autogenerate.compare.schema.inspect", return_value=inspector),
+    ):
+        context = MigrationContext.configure(connection=connection, opts={"compare_type": True})
+        diffs = compare_metadata(context, metadata)
+        assert diffs == [], f"Unexpected diffs: {diffs}"

--- a/test/test_reflection_golden.py
+++ b/test/test_reflection_golden.py
@@ -160,3 +160,120 @@ def test_get_indexes_golden(dialect: CubridDialect, mock_connection: _MockConnec
             "unique": True,
         },
     ]
+
+
+# ---------------------------------------------------------------------------
+# Extended golden tests: multi-column constraints, AUTO_INCREMENT variants
+# ---------------------------------------------------------------------------
+
+
+class _MockConnectionMultiCol:
+    """Mock connection simulating a table with composite PK and multi-column unique."""
+
+    def execute(self, statement: Any, params: Any = None) -> _Result:
+        sql = str(statement)
+        if sql.startswith("SHOW COLUMNS IN"):
+            return _Result([
+                ("tenant_id", "INTEGER", "NO", "PRI", None, ""),
+                ("item_id", "INTEGER", "NO", "PRI", None, "auto_increment"),
+                ("category", "VARCHAR(50)", "NO", "MUL", None, ""),
+                ("sku", "VARCHAR(100)", "NO", "MUL", None, ""),
+                ("price", "DECIMAL(12,4)", "YES", "", "0.0000", ""),
+            ])
+        if sql.startswith("SHOW INDEXES IN"):
+            return _Result([
+                ("items", 1, "pk_items", 1, "tenant_id"),
+                ("items", 1, "pk_items", 2, "item_id"),
+                ("items", 0, "uq_items_tenant_sku", 1, "tenant_id"),
+                ("items", 0, "uq_items_tenant_sku", 2, "sku"),
+                ("items", 1, "idx_items_category", 1, "category"),
+            ])
+        if sql.startswith("SHOW CREATE TABLE"):
+            return _Result([
+                (
+                    "items",
+                    """
+CREATE TABLE [items] (
+  [tenant_id] INTEGER NOT NULL,
+  [item_id] INTEGER NOT NULL AUTO_INCREMENT,
+  [category] VARCHAR(50) NOT NULL,
+  [sku] VARCHAR(100) NOT NULL,
+  [price] DECIMAL(12,4) DEFAULT 0.0000,
+  CONSTRAINT [pk_items] PRIMARY KEY ([tenant_id], [item_id]),
+  CONSTRAINT [uq_items_tenant_sku] UNIQUE KEY ([tenant_id], [sku]),
+  CONSTRAINT [fk_items_tenant] FOREIGN KEY ([tenant_id]) REFERENCES [dba.tenants] ([id]) ON DELETE CASCADE ON UPDATE CASCADE
+)
+""",
+                )
+            ])
+        if "FROM _db_index" in sql:
+            return _Result([
+                ("pk_items", True, False),
+                ("uq_items_tenant_sku", False, False),
+                ("idx_items_category", False, False),
+                ("fk_items_tenant", False, True),
+            ])
+        if "FROM db_constraint" in sql:
+            return _Result([("pk_items",)])
+        if "FROM _db_attribute" in sql:
+            return _Result([
+                ("tenant_id", None),
+                ("item_id", None),
+                ("category", None),
+                ("sku", None),
+                ("price", None),
+            ])
+        raise AssertionError(f"Unexpected SQL: {sql}")
+
+
+@pytest.fixture
+def mock_multicol() -> _MockConnectionMultiCol:
+    return _MockConnectionMultiCol()
+
+
+def test_composite_pk_golden(dialect: CubridDialect, mock_multicol: _MockConnectionMultiCol) -> None:
+    pk = dialect.get_pk_constraint(mock_multicol, "items")
+    assert pk == {"name": "pk_items", "constrained_columns": ["tenant_id", "item_id"]}
+
+
+def test_multi_column_unique_golden(
+    dialect: CubridDialect, mock_multicol: _MockConnectionMultiCol
+) -> None:
+    ucs = dialect.get_unique_constraints(mock_multicol, "items")
+    assert ucs == [{"name": "uq_items_tenant_sku", "column_names": ["tenant_id", "sku"]}]
+
+
+def test_autoincrement_non_first_pk_column(
+    dialect: CubridDialect, mock_multicol: _MockConnectionMultiCol
+) -> None:
+    """AUTO_INCREMENT on item_id (second PK column) should be detected."""
+    columns = [dict(c) for c in dialect.get_columns(mock_multicol, "items")]
+    assert columns[0]["autoincrement"] is False  # tenant_id
+    assert columns[1]["autoincrement"] is True  # item_id
+
+
+def test_foreign_key_cascade_golden(
+    dialect: CubridDialect, mock_multicol: _MockConnectionMultiCol
+) -> None:
+    fks = dialect.get_foreign_keys(mock_multicol, "items")
+    assert fks == [
+        {
+            "name": "fk_items_tenant",
+            "constrained_columns": ["tenant_id"],
+            "referred_schema": None,
+            "referred_table": "tenants",
+            "referred_columns": ["id"],
+            "options": {"ondelete": "CASCADE", "onupdate": "CASCADE"},
+        }
+    ]
+
+
+def test_indexes_exclude_pk_and_unique(
+    dialect: CubridDialect, mock_multicol: _MockConnectionMultiCol
+) -> None:
+    """get_indexes should return only non-PK, non-FK indexes."""
+    indexes = dialect.get_indexes(mock_multicol, "items")
+    assert indexes == [
+        {"name": "uq_items_tenant_sku", "column_names": ["tenant_id", "sku"], "unique": True},
+        {"name": "idx_items_category", "column_names": ["category"], "unique": False},
+    ]


### PR DESCRIPTION
## Summary
- **#171**: Adds multi-column golden reflection tests (composite PK, multi-col unique, AUTO_INCREMENT on non-first PK col, CASCADE FKs)
- **#172**: Adds complex Alembic roundtrip test (composite PK, multiple FKs including self-referential, multi-col unique, server_default)
- **#173**: Extracts `_validate_merge_params()` helper from `visit_merge()` to reduce cognitive complexity

All 668 tests passing.

Closes #171, Closes #172, Closes #173