### PR TITLE
fix: correct get_lastrowid() return type to int | None

### DIFF
--- a/sqlalchemy_cubrid/base.py
+++ b/sqlalchemy_cubrid/base.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import logging
 import re
-from typing import Any, cast
+from typing import Any
 
 from sqlalchemy.engine import default
 from sqlalchemy.sql import compiler
@@ -402,7 +402,7 @@ class CubridExecutionContext(default.DefaultExecutionContext):
     def should_autocommit_text(self, statement: str) -> Any:
         return AUTOCOMMIT_REGEXP.match(statement)
 
-    def get_lastrowid(self) -> int:
+    def get_lastrowid(self) -> int | None:
         """Return the last inserted row ID.
 
         CUBRID's Python driver does not expose ``cursor.lastrowid``.
@@ -415,7 +415,7 @@ class CubridExecutionContext(default.DefaultExecutionContext):
             raw_conn = self.root_connection.connection.dbapi_connection
             if raw_conn is not None and hasattr(raw_conn, "get_last_insert_id"):
                 last_id = raw_conn.get_last_insert_id()
-                return cast(int, None) if last_id is None else int(last_id)  # pyright: ignore[reportInvalidCast]
+                return None if last_id is None else int(last_id)
         except Exception:  # nosec B110 — fallback to SQL when driver lacks method
             log.debug("get_last_insert_id via driver failed, falling back to SQL", exc_info=True)
 
@@ -428,4 +428,4 @@ class CubridExecutionContext(default.DefaultExecutionContext):
                 return int(row[0])
         finally:
             cursor.close()
-        return cast(int, None)  # pyright: ignore[reportInvalidCast]
+        return None

--- a/sqlalchemy_cubrid/pycubrid_dialect.py
+++ b/sqlalchemy_cubrid/pycubrid_dialect.py
@@ -29,11 +29,11 @@ class PyCubridExecutionContext(CubridExecutionContext):
     so we use it directly instead of the CUBRIDdb workaround.
     """
 
-    def get_lastrowid(self) -> int:
+    def get_lastrowid(self) -> int | None:
         """Return the last inserted row ID from pycubrid's cursor."""
         try:
             lastrowid = self.cursor.lastrowid
-            return cast(int, None) if lastrowid is None else int(lastrowid)  # pyright: ignore[reportInvalidCast]
+            return None if lastrowid is None else int(lastrowid)
         except AttributeError:
             pass
 
@@ -46,7 +46,7 @@ class PyCubridExecutionContext(CubridExecutionContext):
                 return int(row[0])
         finally:
             cursor.close()
-        return cast(int, None)  # pyright: ignore[reportInvalidCast]
+        return None
 
 
 class PyCubridDialect(CubridDialect):


### PR DESCRIPTION
## Summary
- Changes `get_lastrowid()` return type from `-> int` to `-> int | None` in both `base.py` and `pycubrid_dialect.py`
- Removes `cast(int, None)` hack (4 occurrences) → plain `return None`
- Removes unused `cast` import from `base.py`
- All 668 tests passing

Closes #175