### PR TITLE
fix: align JSON requirements flag with actual implementation

### DIFF
--- a/sqlalchemy_cubrid/requirements.py
+++ b/sqlalchemy_cubrid/requirements.py
@@ -178,8 +178,8 @@ class Requirements(SuiteRequirements):
 
     @property
     def json_type(self) -> compound:
-        """CUBRID does not support JSON type."""
-        return _CLOSED
+        """CUBRID supports JSON as of version 10.2 (RFC 7159 compliant)."""
+        return _OPEN
 
     @property
     def array_type(self) -> compound:

--- a/test/test_requirements.py
+++ b/test/test_requirements.py
@@ -88,7 +88,7 @@ class TestRequirements:
             ("datetime", True),
             ("timestamp", True),
             ("text_type", True),
-            ("json_type", False),
+            ("json_type", True),
             ("array_type", False),
             ("uuid_data_type", False),
         ],


### PR DESCRIPTION
## Summary
- Changes `json_type` in requirements.py from `_CLOSED` to `_OPEN`
- Updates docstring from "does not support" to "supports JSON as of version 10.2"
- Updates test_requirements.py assertion to expect `True`
- Resolves contradiction between requirements flag and types.py/dialect/tests/README

Closes #176