### PR TITLE
fix: isolate Select._distinct behind _compat helper

### DIFF
--- a/docs/SA_COMPAT.md
+++ b/docs/SA_COMPAT.md
@@ -13,6 +13,7 @@ Verified against: SQLAlchemy `2.0.x` and `2.1.x` (project pin: `>=2.0,<2.2`).
 | `Select._for_update_arg` | `sqlalchemy_cubrid/_compat.py`, `sqlalchemy_cubrid/compiler.py` | Render `FOR UPDATE OF ...` columns | 2.0, 2.1 | `FOR UPDATE` clauses lose `OF` targets or fail to compile |
 | `Select._limit_clause` | `sqlalchemy_cubrid/_compat.py`, `sqlalchemy_cubrid/compiler.py` | Render CUBRID `LIMIT offset, count` form | 2.0, 2.1 | LIMIT/OFFSET SQL generation breaks |
 | `Select._offset_clause` | `sqlalchemy_cubrid/_compat.py`, `sqlalchemy_cubrid/compiler.py` | Render CUBRID `LIMIT offset, count` form | 2.0, 2.1 | OFFSET SQL generation breaks |
+| `Select._distinct` | `sqlalchemy_cubrid/_compat.py`, `sqlalchemy_cubrid/compiler.py` | Render `DISTINCT` prefix in SELECT | 2.0, 2.1 | DISTINCT queries lose the keyword |
 | `sqlalchemy.sql._typing._DMLTableArgument` | `sqlalchemy_cubrid/dml.py` | Type contract for custom `insert/merge/replace` factories | 2.0, 2.1 | Type checking and signatures drift; runtime usually unaffected |
 | `sqlalchemy.sql.base._generative` | `sqlalchemy_cubrid/dml.py` | SQLAlchemy-style immutable statement chaining | 2.0, 2.1 | `on_duplicate_key_update()` / `MERGE` builders become mutable or incorrect |
 | `sqlalchemy.sql.base._exclusive_against` | `sqlalchemy_cubrid/dml.py` | Guard against duplicate post-values clauses | 2.0, 2.1 | Duplicate ODKU clauses can be built without clear errors |
@@ -32,8 +33,8 @@ compiler internals in practice.
 
 ## Risk Summary
 
-- Highest risk: `Select._for_update_arg`, `Select._limit_clause`, and
-  `Select._offset_clause` because they directly affect SQL compilation.
+- Highest risk: `Select._for_update_arg`, `Select._limit_clause`,
+  `Select._offset_clause`, and `Select._distinct` because they directly affect SQL compilation.
 - High risk: `sqlalchemy.connectors.asyncio` adapters and `await_only` because
   the entire async dialect depends on them.
 - Medium risk: `_generative` and `_exclusive_against` because they control

--- a/sqlalchemy_cubrid/_compat.py
+++ b/sqlalchemy_cubrid/_compat.py
@@ -37,3 +37,7 @@ def get_limit_clause(select: Any) -> Any | None:
 
 def get_offset_clause(select: Any) -> Any | None:
     return getattr(select, "_offset_clause", None)
+
+
+def get_distinct(select: Any) -> Any:
+    return getattr(select, "_distinct", False)

--- a/sqlalchemy_cubrid/compiler.py
+++ b/sqlalchemy_cubrid/compiler.py
@@ -17,6 +17,7 @@ from sqlalchemy.sql import sqltypes
 
 from sqlalchemy_cubrid._compat import (
     bind_with_type,
+    get_distinct,
     get_for_update_arg,
     get_limit_clause,
     get_offset_clause,
@@ -65,7 +66,7 @@ class CubridCompiler(compiler.SQLCompiler):
         return rendered
 
     def get_select_precolumns(self, select: Any, **kw: Any) -> str:
-        if bool(select._distinct):
+        if bool(get_distinct(select)):
             return "DISTINCT "
         return ""
 


### PR DESCRIPTION
## Summary
- Adds `get_distinct(select)` helper to `_compat.py`, wrapping `Select._distinct` access
- Updates `compiler.py` line 68 to use `get_distinct()` instead of direct `select._distinct`
- Updates `SA_COMPAT.md` to document the new internal API dependency

Closes #177

## Testing
617 offline tests pass.