### PR TITLE
fix: batch 4 correctness fixes for 1.0 readiness (#181-#184)

### DIFF
--- a/sqlalchemy_cubrid/compiler.py
+++ b/sqlalchemy_cubrid/compiler.py
@@ -46,6 +46,7 @@ class CubridCompiler(compiler.SQLCompiler):
             "collection via TABLE(column), e.g.: "
             "SELECT (SELECT COUNT(*) FROM TABLE(t.tags) AS u) FROM t"
         )
+
     def visit_group_concat_func(self, fn: Any, **kw: Any) -> str:
         """Render GROUP_CONCAT aggregate function.
 
@@ -131,7 +132,7 @@ class CubridCompiler(compiler.SQLCompiler):
     def update_limit_clause(self, update_stmt: Any) -> str | None:  # pyright: ignore[reportIncompatibleMethodOverride]
         # https://www.cubrid.org/manual/en/11.0/sql/query/update.html
         limit = update_stmt.kwargs.get(f"{self.dialect.name}_limit", None)
-        if limit:
+        if limit is not None:
             return f"LIMIT {limit}"
         return None
 

--- a/sqlalchemy_cubrid/dialect.py
+++ b/sqlalchemy_cubrid/dialect.py
@@ -243,10 +243,7 @@ class CubridDialect(default.DefaultDialect):
     @classmethod
     def import_dbapi(cls) -> DBAPIModule:
         """Import and return the CUBRID DBAPI module (SA 2.0 API)."""
-        try:
-            import CUBRIDdb as cubrid_dbapi  # type: ignore[import-not-found]  # pyright: ignore[reportMissingImports]
-        except ImportError as e:
-            raise e
+        import CUBRIDdb as cubrid_dbapi  # type: ignore[import-not-found]  # pyright: ignore[reportMissingImports]
         return cast(DBAPIModule, cubrid_dbapi)  # pyright: ignore[reportInvalidCast]
 
     # Keep legacy dbapi() for SA 1.x compat if needed
@@ -331,6 +328,10 @@ class CubridDialect(default.DefaultDialect):
 
                     util.warn("Did not recognize type '%s' of column '%s'" % (coltype_raw, colname))
                     coltype = sqltypes.NULLTYPE
+
+            # Preserve timezone=True for TZ/LTZ type variants (#181)
+            if coltype_key.endswith(("TZ", "LTZ")) and hasattr(coltype, "timezone"):
+                coltype = coltype.__class__(timezone=True)
 
             columns.append(
                 {

--- a/sqlalchemy_cubrid/pycubrid_dialect.py
+++ b/sqlalchemy_cubrid/pycubrid_dialect.py
@@ -70,10 +70,7 @@ class PyCubridDialect(CubridDialect):
     @classmethod
     def import_dbapi(cls) -> DBAPIModule:
         """Import and return the pycubrid DBAPI module."""
-        try:
-            dbapi_module = import_module("pycubrid")
-        except ImportError as e:
-            raise e
+        dbapi_module = import_module("pycubrid")
         log.debug("Loaded pycubrid DBAPI (version %s)", getattr(dbapi_module, "__version__", "?"))
         return cast(DBAPIModule, dbapi_module)  # pyright: ignore[reportInvalidCast]
 

--- a/sqlalchemy_cubrid/types.py
+++ b/sqlalchemy_cubrid/types.py
@@ -268,7 +268,7 @@ class STRING(_StringType):
     __visit_name__ = "STRING"
 
     def __init__(self, length: int | None = None, national: bool = False, **kwargs: Any) -> None:
-        super().__init__(length=length, **kwargs)
+        super().__init__(length=length, national=national, **kwargs)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **#181**: TZ type reflection preserves `timezone=True` — `get_columns()` post-processes `TIMESTAMPTZ`/`DATETIMETZ` etc. to reconstruct with `timezone=True`
- **#182**: `STRING.__init__()` passes `national` kwarg to parent `_StringType`
- **#183**: `update_limit_clause()` uses `is not None` instead of truthy check (fixes `LIMIT 0`); added missing PEP 8 blank line
- **#184**: Removed useless `try/except ImportError: raise e` in `import_dbapi()` (both dialects)

Closes #181, #182, #183, #184

## Testing
617 offline tests pass. All changes are minimal correctness fixes per Oracle design review (86/100 batch approval).