### PR TITLE
test: regression tests for batch 4 correctness fixes

### DIFF
--- a/test/test_compiler.py
+++ b/test/test_compiler.py
@@ -811,6 +811,15 @@ class TestUpdateCompilation:
         sql = _compile(stmt)
         assert "UPDATE" in sql
 
+    def test_update_with_limit_zero(self):
+        """Regression: LIMIT 0 must not be silently dropped. (#183)"""
+        from sqlalchemy import update
+
+        stmt = update(users).values(name="test")
+        stmt.kwargs["cubrid_limit"] = 0
+        sql = _compile(stmt)
+        assert "LIMIT 0" in sql
+
     def test_update_from_raises_compile_error(self):
         t1 = sa.table("t1", sa.column("id"), sa.column("val"))
         t2 = sa.table("t2", sa.column("id"), sa.column("rate"))

--- a/test/test_dialect_offline.py
+++ b/test/test_dialect_offline.py
@@ -339,6 +339,37 @@ class TestReflectionMethods:
         assert columns[6]["comment"] is None
         warn.assert_called_once()
 
+    def test_get_columns_preserves_timezone_for_tz_types(self):
+        """Regression: TIMESTAMPTZ/DATETIMETZ reflection must set timezone=True. (#181)"""
+        dialect = CubridDialect()
+        connection = MagicMock()
+        connection.info_cache = {}
+        connection.dialect_options = {}
+
+        rows = [
+            ("ts_col", "TIMESTAMP", "YES", "", None, ""),
+            ("tstz_col", "TIMESTAMPTZ", "YES", "", None, ""),
+            ("tsltz_col", "TIMESTAMPLTZ", "YES", "", None, ""),
+            ("dt_col", "DATETIME", "YES", "", None, ""),
+            ("dttz_col", "DATETIMETZ", "YES", "", None, ""),
+            ("dtltz_col", "DATETIMELTZ", "YES", "", None, ""),
+        ]
+        comment_rows = []
+        connection.execute.side_effect = [rows, comment_rows]
+
+        columns = _invoke_reflection(dialect, "get_columns", connection, "tz_table")
+
+        assert len(columns) == 6
+        # Plain types: no timezone
+        assert getattr(columns[0]["type"], "timezone", False) is False
+        assert getattr(columns[3]["type"], "timezone", False) is False
+        # TZ/LTZ types: timezone=True
+        assert columns[1]["type"].timezone is True  # TIMESTAMPTZ
+        assert columns[2]["type"].timezone is True  # TIMESTAMPLTZ
+        assert columns[4]["type"].timezone is True  # DATETIMETZ
+        assert columns[5]["type"].timezone is True  # DATETIMELTZ
+
+
     def test_get_pk_constraint_with_primary_key_and_constraint_name(self):
         dialect = CubridDialect()
         connection = MagicMock()

--- a/test/test_types.py
+++ b/test/test_types.py
@@ -175,6 +175,12 @@ class TestTypeInstantiation:
         t = STRING()
         assert isinstance(t, sqltypes.String)
 
+    def test_string_national_passed_to_parent(self):
+        """Regression: STRING(national=True) must propagate to _StringType. (#182)"""
+        t = STRING(national=True)
+        assert t.national is True
+
+
     def test_blob(self):
         t = BLOB()
         assert isinstance(t, sqltypes.LargeBinary)


### PR DESCRIPTION
## Summary
Adds 3 targeted regression tests per Oracle review recommendation (91/100 score):

- **TZ reflection** (#181): Verifies `TIMESTAMPTZ`/`TIMESTAMPLTZ`/`DATETIMETZ`/`DATETIMELTZ` reflection preserves `timezone=True`
- **STRING national** (#182): Verifies `STRING(national=True)` propagates to parent `_StringType`
- **UPDATE LIMIT 0** (#183): Verifies `LIMIT 0` is not silently dropped by truthy check

## Testing
620 tests pass (617 existing + 3 new).