### PR TITLE
fix: replace try/except/pass in trace.py to clear bandit B110

### DIFF
--- a/sqlalchemy_cubrid/trace.py
+++ b/sqlalchemy_cubrid/trace.py
@@ -23,11 +23,14 @@ Usage::
 
 from __future__ import annotations
 
+import logging
 from typing import Any, Mapping, Sequence
 
 from sqlalchemy import text
 from sqlalchemy.engine import Connection
 from sqlalchemy.sql.expression import Executable
+
+_logger = logging.getLogger(__name__)
 
 __all__ = ("trace_query",)
 
@@ -93,7 +96,10 @@ def trace_query(
 
         return trace_output
     finally:
+        # Best-effort cleanup: intentionally swallow any exception from
+        # `SET TRACE OFF` so we never mask the original exception (if any)
+        # raised inside the try block. Log at debug level for observability.
         try:
             connection.execute(text("SET TRACE OFF"))
-        except Exception:  # noqa: BLE001 — never mask the original exception
-            pass
+        except Exception as exc:  # noqa: BLE001 - cleanup must not mask original error
+            _logger.debug("Failed to disable CUBRID trace during cleanup: %s", exc)


### PR DESCRIPTION
## Summary

Resolves #210.

Replace the silent `try / except Exception: pass` cleanup block in
`sqlalchemy_cubrid/trace.py::trace_query` with an explicit `logger.debug(...)`
call. Bandit B110 (`try_except_pass`, Low / High) no longer fires, while the
existing behavior of **never masking the original exception during cleanup**
is preserved.

## Changes

- Add module-level `_logger = logging.getLogger(__name__)`
- Replace `except Exception: pass` with `except Exception as exc: _logger.debug(...)`
- Add a brief comment explaining the intentional swallow

## Verification

- `bandit -r sqlalchemy_cubrid/trace.py` → **No issues identified**
- `ruff check` + `ruff format --check` → clean
- `pytest test/test_trace.py` → **9 passed** (including `test_trace_query_always_disables_trace` covering the `finally` path)

## Acceptance criteria

- [x] bandit clean on `main` (Security Scans should be green once merged)
- [x] Behavior at the call site preserved (no functional change to tracing; failures during cleanup are now logged at DEBUG instead of fully silent)
- [x] Brief comment explaining why the exception is intentionally swallowed