### PR TITLE
feat: expand SQLAlchemy support to 2.0–2.2 with 2.1/2.2 compat shims (#206)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,6 @@ jobs:
 
   sqlalchemy-22-canary:
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -110,7 +109,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
-          pip install --pre "sqlalchemy>=2.2.0b1,<2.3"
+          pip install --pre "sqlalchemy>=2.1.0b1,<2.3"
       - name: Run offline tests (canary)
         run: |
           python -m pytest \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **SQLAlchemy 2.1 / forward-compat shims for SA 2.2 (#206)** — dependency upper bound bumped to `<2.3` (now `sqlalchemy>=2.0,<2.3`), enabling installation on SA 2.1 and future 2.2 releases. New `CubridCompiler.update_post_criteria_clause` override routes the existing `cubrid_limit` LIMIT rendering through the SA 2.1 hook that replaced `update_limit_clause`. `_render_json_extract_from_binary` now recognises `Float` as a numeric affinity since SA 2.1 split it out of `Numeric`, restoring `CAST(... AS DOUBLE)` emission for `JSON[...].as_float()`. `AsyncAdapt_pycubrid_connection.await_` is redeclared as a class-level staticmethod because SA 2.1 dropped the inherited attribute on `AsyncAdapt_dbapi_connection`. Cross-version offline test suite (639 tests) green on both SA 2.0.49 and SA 2.1.0b2.
+- **`sqlalchemy-22-canary` CI job promoted to gating (#206)** — previously `continue-on-error: true` against a non-existent `sqlalchemy>=2.2.0b1`. Now installs `--pre "sqlalchemy>=2.1.0b1,<2.3"` so the job actually exercises the latest available SA pre-release and fails the build on regressions.
+
 ### Fixed
 - **Async integration stability for issue #208** — `test/test_aio_integration.py` now seeds per-test data instead of relying on module-shared CRUD state, adds live `pool_pre_ping=True` recovery coverage after an internal async transport drop, and verifies async SQLAlchemy INSERT returns `lastrowid` without adding a new `AsyncAdapt_pycubrid_connection.get_last_insert_id()` passthrough because async pycubrid already populates `cursor.lastrowid` and the dialect retains SQL fallback.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # sqlalchemy-cubrid
 
-**SQLAlchemy 2.0–2.1 dialect for the CUBRID database** — Python ORM, schema reflection, Alembic migrations, and type mapping for SQLAlchemy and CUBRID-specific types.
+**SQLAlchemy 2.0–2.2 dialect for the CUBRID database** — Python ORM, schema reflection, Alembic migrations, and type mapping for SQLAlchemy and CUBRID-specific types.
 
 [🇰🇷 한국어](docs/README.ko.md) · [🇺🇸 English](README.md) · [🇨🇳 中文](docs/README.zh.md) · [🇮🇳 हिन्दी](docs/README.hi.md) · [🇩🇪 Deutsch](docs/README.de.md) · [🇷🇺 Русский](docs/README.ru.md)
 
@@ -17,20 +17,20 @@
 
 ---
 
-> **Status: Production/Stable** — `sqlalchemy-cubrid` is a maintained SQLAlchemy dialect for CUBRID supporting SQLAlchemy 2.0–2.1 and CUBRID 10.2–11.4.
+> **Status: Production/Stable** — `sqlalchemy-cubrid` is a maintained SQLAlchemy dialect for CUBRID supporting SQLAlchemy 2.0–2.2 and CUBRID 10.2–11.4.
 
 ## Why sqlalchemy-cubrid?
 
 CUBRID is a high-performance open-source relational database, widely adopted in
 Korean public-sector and enterprise applications. Until now, there was no
-actively maintained SQLAlchemy dialect that supports the modern 2.0–2.1 API.
+actively maintained SQLAlchemy dialect that supports the modern 2.0–2.2 API.
 
 **sqlalchemy-cubrid** bridges that gap:
 
-- Full SQLAlchemy 2.0–2.1 dialect with **statement caching** and **PEP 561 typing**
+- Full SQLAlchemy 2.0–2.2 dialect with **statement caching** and **PEP 561 typing**
 - **Extensive offline test suite** with **high code coverage** ([CI badge above](https://github.com/cubrid-lab/sqlalchemy-cubrid/actions/workflows/ci.yml)) — no database required to run them
 - **Concurrency stress tests** — `QueuePool` sync threaded + asyncio.gather workloads validated against live CUBRID
-- **SQLAlchemy 2.2-ready compat shim** — private API access wrapped in `_compat.py` (still pinned `<2.2` until full SA 2.2 validation)
+- **SQLAlchemy 2.2-ready compat shim** — private API access wrapped in `_compat.py`; dependency pin now `>=2.0,<2.3` covering SA 2.0, 2.1, and the upcoming 2.2 release line
 - Tested against **4 CUBRID versions** (10.2, 11.0, 11.2, 11.4) across **Python 3.10 -- 3.14**
 - CUBRID-specific DML constructs: `ON DUPLICATE KEY UPDATE`, `MERGE`, `REPLACE INTO`
 - Alembic migration support out of the box
@@ -39,7 +39,7 @@ actively maintained SQLAlchemy dialect that supports the modern 2.0–2.1 API.
 ## Support Status
 
 - **Status**: Production/Stable [![PyPI version](https://img.shields.io/pypi/v/sqlalchemy-cubrid)](https://pypi.org/project/sqlalchemy-cubrid)
-- Supported matrix: SQLAlchemy `>=2.0,<2.2`, CUBRID `10.2`, `11.0`, `11.2`, `11.4`, Python `3.10`–`3.14`
+- Supported matrix: SQLAlchemy `>=2.0,<2.3`, CUBRID `10.2`, `11.0`, `11.2`, `11.4`, Python `3.10`–`3.14`
 - Integration CI exercises Python 3.10 and 3.14 against all four CUBRID versions on every PR; intermediate versions (3.11–3.13) are supported and validated via the offline test suite
 - SQLAlchemy `2.2` remains canary-only until explicitly added to the supported matrix
 - See [Known Limitations](#known-limitations) for behavior boundaries and unsupported features
@@ -66,7 +66,7 @@ flowchart TD
 ## Requirements
 
 - Python 3.10+
-- SQLAlchemy 2.0 – 2.1
+- SQLAlchemy 2.0 – 2.2
 - [CUBRID-Python](https://github.com/CUBRID/cubrid-python) (C-extension) **or** [pycubrid](https://github.com/sqlalchemy-cubrid/pycubrid) (pure Python)
 
 ## Installation
@@ -159,7 +159,7 @@ async with AsyncSession(engine) as session:
 - **No sequences** — CUBRID uses `AUTO_INCREMENT` only
 - **No multi-schema** — single schema per database
 - **DDL auto-commits** — migrations are not transactional (`transactional_ddl = False`); use Alembic batch migrations and test rollback scenarios manually
-- **SQLAlchemy 2.0–2.1 only** — pinned to `<2.2` due to internal API dependencies ([details](docs/ARCHITECTURE.md))
+- **SQLAlchemy 2.0–2.2 only** — pinned to `<2.3`; SA 2.2 is forward-supported via shims and a `--pre` canary CI job ([details](docs/ARCHITECTURE.md))
 - **Async requires pycubrid >= 1.3.2,<2.0** — the `cubrid+aiopycubrid://` driver needs the async-capable pycubrid package line currently supported by this project
 - **CARDINALITY() broken** — `func.cardinality()` raises `CompileError` with workaround guidance; the CUBRID server has a [known bug](https://github.com/cubrid-lab/.github/issues/3)
 - **Reserved words auto-quoted** — Column names matching CUBRID reserved words (`day`, `count`, `value`, etc.) are automatically double-quoted in DDL; see [reserved word list](https://github.com/cubrid-lab/.github/issues/5)
@@ -187,7 +187,7 @@ async with AsyncSession(engine) as session:
 |---|---|
 | Python | 3.10, 3.11, 3.12, 3.13, 3.14 |
 | CUBRID | 10.2, 11.0, 11.2, 11.4 |
-| SQLAlchemy | 2.0–2.1 |
+| SQLAlchemy | 2.0–2.2 |
 | Alembic | >=1.7 |
 | pycubrid (sync) | >=1.3.2,<2.0 |
 | pycubrid (async) | >=1.3.2,<2.0 |
@@ -203,9 +203,9 @@ engine = create_engine("cubrid://dba:password@localhost:33000/demodb")
 
 For the pure Python driver (no C build needed): `create_engine("cubrid+pycubrid://dba@localhost:33000/demodb")`
 
-### Does sqlalchemy-cubrid support SQLAlchemy 2.0–2.1?
+### Does sqlalchemy-cubrid support SQLAlchemy 2.0–2.2?
 
-Yes. sqlalchemy-cubrid is built for SQLAlchemy 2.0–2.1 and supports the 2.0-style API including `Session.execute()`, typed `Mapped[]` columns, and statement caching.
+Yes. sqlalchemy-cubrid is built for SQLAlchemy 2.0–2.2 and supports the 2.0-style API including `Session.execute()`, typed `Mapped[]` columns, and statement caching.
 
 ### Does sqlalchemy-cubrid support Alembic migrations?
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,7 +14,7 @@
 ## Current Release Line — v1.4.x — Stable Maintenance & Polish
 
 - Documentation accuracy and consistency across README / docs / AI-facing project files
-- Continued SQLAlchemy 2.0–2.1 hardening while preparing for SA 2.2 validation
+- Continued SQLAlchemy 2.0–2.2 hardening while preparing for SA 2.2 validation
 - Reflection/autogenerate polish and benchmark-driven performance tuning
 
 ## Next Minor — v1.5.x — Performance & Ecosystem
@@ -25,7 +25,7 @@
 
 ## Compatibility
 
-Python 3.10+, SQLAlchemy 2.0–2.1, CUBRID 10.2–11.4
+Python 3.10+, SQLAlchemy 2.0–2.2, CUBRID 10.2–11.4
 
 ## Completed
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,7 +3,7 @@
 ## Design Objectives
 sqlalchemy-cubrid is designed to provide a robust, modern interface between SQLAlchemy and the CUBRID database. Its core design goals include:
 
-*   Full SQLAlchemy 2.0–2.1 dialect implementation
+*   Full SQLAlchemy 2.0–2.2 dialect implementation
 *   Three driver modes (C-extension CUBRIDdb + pure Python pycubrid + async pycubrid.aio)
 *   Schema reflection (tables, columns, constraints, indexes, comments)
 *   Custom DML extensions (ON DUPLICATE KEY UPDATE, MERGE, REPLACE)

--- a/docs/CONNECTION.md
+++ b/docs/CONNECTION.md
@@ -186,7 +186,7 @@ engine = create_engine(
     # Set default isolation level for all connections
     isolation_level="REPEATABLE READ",
 
-     # SQLAlchemy 2.0–2.1 connection pool settings
+     # SQLAlchemy 2.0–2.2 connection pool settings
     pool_size=5,
     max_overflow=10,
     pool_timeout=30,

--- a/docs/FEATURE_SUPPORT.md
+++ b/docs/FEATURE_SUPPORT.md
@@ -478,4 +478,4 @@ Features not currently supported that may be added in future releases, depending
 
 ---
 
-*Last updated: April 2026 · sqlalchemy-cubrid v1.4.0 Beta · SQLAlchemy 2.0–2.1*
+*Last updated: April 2026 · sqlalchemy-cubrid v1.4.0 Beta · SQLAlchemy 2.0–2.2*

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,4 +1,4 @@
-# PRD: sqlalchemy-cubrid — CUBRID Dialect for SQLAlchemy 2.0–2.1
+# PRD: sqlalchemy-cubrid — CUBRID Dialect for SQLAlchemy 2.0–2.2
 
 ## 1. Overview
 
@@ -18,9 +18,9 @@ The original `sqlalchemy-cubrid` project was abandoned and broken:
 
 ### 1.2 What Was Built
 
-A complete ground-up rewrite delivering a modern CUBRID dialect for SQLAlchemy 2.0–2.1:
+A complete ground-up rewrite delivering a modern CUBRID dialect for SQLAlchemy 2.0–2.2:
 
-- **Full SQLAlchemy 2.0–2.1 dialect** with statement caching
+- **Full SQLAlchemy 2.0–2.2 dialect** with statement caching
 - **Complete SQL feature coverage** — everything CUBRID supports is enabled
 - **Comprehensive type system** — 20+ types including CUBRID-specific collections and JSON
 - **Schema reflection** — tables, views, columns, PKs, FKs, indexes, unique constraints, comments
@@ -36,7 +36,7 @@ A complete ground-up rewrite delivering a modern CUBRID dialect for SQLAlchemy 2
 | Criterion | Target | Achieved |
 |---|---|---|
 | Installable on Python 3.10+ | ✅ | ✅ `pip install sqlalchemy-cubrid` |
-| SQLAlchemy 2.0 – 2.1 compatible | ✅ | ✅ Full API compliance |
+| SQLAlchemy 2.0 – 2.2 compatible | ✅ | ✅ Full API compliance |
 | Offline tests (no live DB) | ✅ | ✅ 619 tests, ~98.26% coverage |
 | All dialect methods implemented | ✅ | ✅ Reflection, compilation, types |
 | CI/CD with version matrix | ✅ | ✅ Py 3.10–3.14 × CUBRID 10.2–11.4 |

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -54,7 +54,7 @@ engine = create_engine("cubrid://dba@localhost:33000/testdb")
 
 ```mermaid
 flowchart TD
-    app[Application Code] --> sa[SQLAlchemy 2.0–2.1]
+    app[Application Code] --> sa[SQLAlchemy 2.0–2.2]
     sa --> dialect[sqlalchemy-cubrid]
     dialect --> cext[CUBRIDdb]
     dialect --> pure[pycubrid]

--- a/docs/README.de.md
+++ b/docs/README.de.md
@@ -1,6 +1,6 @@
 # sqlalchemy-cubrid
 
-**SQLAlchemy-2.0–2.1-Dialekt für die CUBRID-Datenbank** — Python-ORM, Schema-Reflexion, Alembic-Migrationen und Typzuordnung für SQLAlchemy und CUBRID-spezifische Typen.
+**SQLAlchemy-2.0–2.2-Dialekt für die CUBRID-Datenbank** — Python-ORM, Schema-Reflexion, Alembic-Migrationen und Typzuordnung für SQLAlchemy und CUBRID-spezifische Typen.
 
 [🇰🇷 한국어](README.ko.md) · [🇺🇸 English](../README.md) · [🇨🇳 中文](README.zh.md) · [🇮🇳 हिन्दी](README.hi.md) · [🇩🇪 Deutsch](README.de.md) · [🇷🇺 Русский](README.ru.md)
 
@@ -23,15 +23,15 @@
 
 CUBRID ist eine leistungsstarke relationale Open-Source-Datenbank, die in
 koreanischen Behörden und Unternehmensanwendungen weit verbreitet ist. Bislang
-gab es keinen aktiv gepflegten SQLAlchemy-Dialekt, der die moderne 2.0–2.1-API
+gab es keinen aktiv gepflegten SQLAlchemy-Dialekt, der die moderne 2.0–2.2-API
 unterstützt.
 
 **sqlalchemy-cubrid** schließt diese Lücke:
 
-- Vollständiger SQLAlchemy-2.0–2.1-Dialekt mit **Statement-Caching** und **PEP-561-Typisierung**
+- Vollständiger SQLAlchemy-2.0–2.2-Dialekt mit **Statement-Caching** und **PEP-561-Typisierung**
 - **619 Offline-Tests** mit **~98,26 % Codeabdeckung** — zum Ausführen ist keine Datenbank erforderlich
 - **Nebenläufigkeits-Stresstests** — `QueuePool`-basierte synchrone Threads + `asyncio.gather`-Workloads gegen echtes CUBRID validiert
-- **SQLAlchemy-2.2-fähiger Compat-Shim** — Zugriff auf private APIs in `_compat.py` gekapselt (bis zur vollständigen SA-2.2-Validierung weiterhin auf `<2.2` festgelegt)
+- **SQLAlchemy-2.2-fähiger Compat-Shim** — Zugriff auf private APIs in `_compat.py` gekapselt (bis zur vollständigen SA-2.2-Validierung weiterhin auf `<2.3` festgelegt)
 - Gegen **4 CUBRID-Versionen** (10.2, 11.0, 11.2, 11.4) auf **Python 3.10 -- 3.14** getestet
 - CUBRID-spezifische DML-Konstrukte: `ON DUPLICATE KEY UPDATE`, `MERGE`, `REPLACE INTO`
 - Alembic-Migrationsunterstützung sofort einsatzbereit
@@ -59,7 +59,7 @@ flowchart TD
 ## Anforderungen
 
 - Python 3.10+
-- SQLAlchemy 2.0 – 2.1
+- SQLAlchemy 2.0 – 2.2
 - [CUBRID-Python](https://github.com/CUBRID/cubrid-python) (C-Erweiterung) **oder** [pycubrid](https://github.com/cubrid-lab/pycubrid) (reines Python)
 
 ## Installation
@@ -152,7 +152,7 @@ async with AsyncSession(engine) as session:
 - **Keine Sequenzen** — CUBRID verwendet ausschließlich `AUTO_INCREMENT`
 - **Kein Multi-Schema** — ein einzelnes Schema pro Datenbank
 - **DDL committet automatisch** — Migrationen sind nicht transaktional (`transactional_ddl = False`)
-- **Nur SQLAlchemy 2.0–2.1** — wegen interner API-Abhängigkeiten auf `<2.2` festgelegt ([Details](ARCHITECTURE.md))
+- **Nur SQLAlchemy 2.0–2.2** — wegen interner API-Abhängigkeiten auf `<2.3` festgelegt ([Details](ARCHITECTURE.md))
 - **Async erfordert pycubrid >= 1.2.0,<2.0** — der Treiber `cubrid+aiopycubrid://` benötigt die von diesem Projekt aktuell unterstützte async-fähige pycubrid-Paketlinie
 
 ## Dokumentation
@@ -177,7 +177,7 @@ async with AsyncSession(engine) as session:
 |---|---|
 | Python | 3.10, 3.11, 3.12, 3.13, 3.14 |
 | CUBRID | 10.2, 11.0, 11.2, 11.4 |
-| SQLAlchemy | 2.0–2.1 |
+| SQLAlchemy | 2.0–2.2 |
 | Alembic | >=1.7 |
 | pycubrid (sync) | >=1.2.0,<2.0 |
 | pycubrid (async) | >=1.2.0,<2.0 |
@@ -193,9 +193,9 @@ engine = create_engine("cubrid://dba:password@localhost:33000/demodb")
 
 Für den Pure-Python-Treiber (kein C-Build erforderlich): `create_engine("cubrid+pycubrid://dba@localhost:33000/demodb")`
 
-### Unterstützt sqlalchemy-cubrid SQLAlchemy 2.0–2.1?
+### Unterstützt sqlalchemy-cubrid SQLAlchemy 2.0–2.2?
 
-Ja. sqlalchemy-cubrid wurde für SQLAlchemy 2.0–2.1 entwickelt und unterstützt die API im 2.0-Stil einschließlich `Session.execute()`, typisierter `Mapped[]`-Spalten und Statement-Caching.
+Ja. sqlalchemy-cubrid wurde für SQLAlchemy 2.0–2.2 entwickelt und unterstützt die API im 2.0-Stil einschließlich `Session.execute()`, typisierter `Mapped[]`-Spalten und Statement-Caching.
 
 ### Unterstützt sqlalchemy-cubrid Alembic-Migrationen?
 

--- a/docs/README.hi.md
+++ b/docs/README.hi.md
@@ -1,6 +1,6 @@
 # sqlalchemy-cubrid
 
-**CUBRID डेटाबेस के लिए SQLAlchemy 2.0–2.1 dialect** — SQLAlchemy और CUBRID-विशिष्ट types के लिए Python ORM, schema reflection, Alembic migrations, और type mapping प्रदान करता है।
+**CUBRID डेटाबेस के लिए SQLAlchemy 2.0–2.2 dialect** — SQLAlchemy और CUBRID-विशिष्ट types के लिए Python ORM, schema reflection, Alembic migrations, और type mapping प्रदान करता है।
 
 [🇰🇷 한국어](README.ko.md) · [🇺🇸 English](../README.md) · [🇨🇳 中文](README.zh.md) · [🇮🇳 हिन्दी](README.hi.md) · [🇩🇪 Deutsch](README.de.md) · [🇷🇺 Русский](README.ru.md)
 
@@ -17,20 +17,20 @@
 
 ---
 
-> **स्थिति: Production/Stable** — CUBRID 10.2–11.4 और SQLAlchemy 2.0–2.1 के लिए स्थिर रूप से रखरखाव किया गया dialect। प्रत्येक PR को लाइव DB इंटीग्रेशन CI द्वारा सत्यापित किया जाता है।
+> **स्थिति: Production/Stable** — CUBRID 10.2–11.4 और SQLAlchemy 2.0–2.2 के लिए स्थिर रूप से रखरखाव किया गया dialect। प्रत्येक PR को लाइव DB इंटीग्रेशन CI द्वारा सत्यापित किया जाता है।
 
 ## sqlalchemy-cubrid क्यों?
 
 CUBRID एक उच्च-प्रदर्शन ओपन-सोर्स रिलेशनल डेटाबेस है, जिसका उपयोग कोरियाई सार्वजनिक
 क्षेत्र और एंटरप्राइज़ अनुप्रयोगों में व्यापक रूप से किया जाता है। अब तक ऐसा कोई
-सक्रिय रूप से maintained SQLAlchemy dialect नहीं था जो आधुनिक 2.0–2.1 API को सपोर्ट करे।
+सक्रिय रूप से maintained SQLAlchemy dialect नहीं था जो आधुनिक 2.0–2.2 API को सपोर्ट करे।
 
 **sqlalchemy-cubrid** इस कमी को पूरा करता है:
 
-- **statement caching** और **PEP 561 typing** के साथ पूर्ण SQLAlchemy 2.0–2.1 dialect
+- **statement caching** और **PEP 561 typing** के साथ पूर्ण SQLAlchemy 2.0–2.2 dialect
 - **619 ऑफ़लाइन टेस्ट** और **लगभग 98.26% code coverage** — इन्हें चलाने के लिए डेटाबेस की आवश्यकता नहीं
 - **Concurrency stress tests** — `QueuePool` sync threaded + `asyncio.gather` workloads को live CUBRID पर validate किया गया है
-- **SQLAlchemy 2.2-ready compat shim** — private API access को `_compat.py` में wrap किया गया है (पूर्ण SA 2.2 validation तक अभी भी `<2.2` पर pinned)
+- **SQLAlchemy 2.2-ready compat shim** — private API access को `_compat.py` में wrap किया गया है (पूर्ण SA 2.2 validation तक अभी भी `<2.3` पर pinned)
 - **Python 3.10 -- 3.14** पर **4 CUBRID versions** (10.2, 11.0, 11.2, 11.4) के खिलाफ टेस्ट किया गया
 - CUBRID-विशिष्ट DML constructs: `ON DUPLICATE KEY UPDATE`, `MERGE`, `REPLACE INTO`
 - Alembic migration support box से बाहर उपलब्ध
@@ -58,7 +58,7 @@ flowchart TD
 ## आवश्यकताएँ
 
 - Python 3.10+
-- SQLAlchemy 2.0 – 2.1
+- SQLAlchemy 2.0 – 2.2
 - [CUBRID-Python](https://github.com/CUBRID/cubrid-python) (C-extension) **या** [pycubrid](https://github.com/cubrid-lab/pycubrid) (pure Python)
 
 ## इंस्टॉलेशन
@@ -151,7 +151,7 @@ async with AsyncSession(engine) as session:
 - **कोई sequences नहीं** — CUBRID केवल `AUTO_INCREMENT` का उपयोग करता है
 - **कोई multi-schema नहीं** — प्रति डेटाबेस एक single schema
 - **DDL auto-commit करता है** — migrations transactional नहीं हैं (`transactional_ddl = False`)
-- **केवल SQLAlchemy 2.0–2.1** — internal API dependencies के कारण `<2.2` पर pinned ([details](ARCHITECTURE.md))
+- **केवल SQLAlchemy 2.0–2.2** — internal API dependencies के कारण `<2.3` पर pinned ([details](ARCHITECTURE.md))
 - **Async के लिए pycubrid >= 1.2.0,<2.0 आवश्यक है** — `cubrid+aiopycubrid://` driver को वही async-capable pycubrid package line चाहिए जिसे यह परियोजना वर्तमान में सपोर्ट करती है
 
 ## दस्तावेज़ीकरण
@@ -176,7 +176,7 @@ async with AsyncSession(engine) as session:
 |---|---|
 | Python | 3.10, 3.11, 3.12, 3.13, 3.14 |
 | CUBRID | 10.2, 11.0, 11.2, 11.4 |
-| SQLAlchemy | 2.0–2.1 |
+| SQLAlchemy | 2.0–2.2 |
 | Alembic | >=1.7 |
 | pycubrid (sync) | >=1.2.0,<2.0 |
 | pycubrid (async) | >=1.2.0,<2.0 |
@@ -192,9 +192,9 @@ engine = create_engine("cubrid://dba:password@localhost:33000/demodb")
 
 Pure Python driver के लिए (C build की आवश्यकता नहीं): `create_engine("cubrid+pycubrid://dba@localhost:33000/demodb")`
 
-### क्या sqlalchemy-cubrid SQLAlchemy 2.0–2.1 को सपोर्ट करता है?
+### क्या sqlalchemy-cubrid SQLAlchemy 2.0–2.2 को सपोर्ट करता है?
 
-हाँ। sqlalchemy-cubrid, SQLAlchemy 2.0–2.1 के लिए बनाया गया है और `Session.execute()`, typed `Mapped[]` columns, और statement caching सहित 2.0-style API को सपोर्ट करता है।
+हाँ। sqlalchemy-cubrid, SQLAlchemy 2.0–2.2 के लिए बनाया गया है और `Session.execute()`, typed `Mapped[]` columns, और statement caching सहित 2.0-style API को सपोर्ट करता है।
 
 ### क्या sqlalchemy-cubrid Alembic migrations को सपोर्ट करता है?
 

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -1,6 +1,6 @@
 # sqlalchemy-cubrid
 
-**CUBRID 데이터베이스를 위한 SQLAlchemy 2.0–2.1 방언** — SQLAlchemy 및 CUBRID 전용 타입을 위한 Python ORM, 스키마 리플렉션, Alembic 마이그레이션, 타입 매핑을 제공합니다.
+**CUBRID 데이터베이스를 위한 SQLAlchemy 2.0–2.2 방언** — SQLAlchemy 및 CUBRID 전용 타입을 위한 Python ORM, 스키마 리플렉션, Alembic 마이그레이션, 타입 매핑을 제공합니다.
 
 [🇰🇷 한국어](README.ko.md) · [🇺🇸 English](../README.md) · [🇨🇳 中文](README.zh.md) · [🇮🇳 हिन्दी](README.hi.md) · [🇩🇪 Deutsch](README.de.md) · [🇷🇺 Русский](README.ru.md)
 
@@ -17,20 +17,20 @@
 
 ---
 
-> **상태: Production/Stable** — CUBRID 10.2–11.4 및 SQLAlchemy 2.0–2.1을 지원하는 유지보수 다이얼렉트입니다. 모든 PR에 대해 라이브 DB 통합 CI가 실행됩니다.
+> **상태: Production/Stable** — CUBRID 10.2–11.4 및 SQLAlchemy 2.0–2.2을 지원하는 유지보수 다이얼렉트입니다. 모든 PR에 대해 라이브 DB 통합 CI가 실행됩니다.
 
 ## 왜 sqlalchemy-cubrid인가?
 
 CUBRID는 고성능 오픈소스 관계형 데이터베이스로, 한국 공공기관 및 기업 환경에서
-널리 사용되고 있습니다. 지금까지 최신 2.0–2.1 API를 지원하는 SQLAlchemy 방언은
+널리 사용되고 있습니다. 지금까지 최신 2.0–2.2 API를 지원하는 SQLAlchemy 방언은
 활발히 유지보수되지 않았습니다.
 
 **sqlalchemy-cubrid**는 이 공백을 메웁니다:
 
-- **statement caching**과 **PEP 561 타입 지원**을 갖춘 완전한 SQLAlchemy 2.0–2.1 방언
+- **statement caching**과 **PEP 561 타입 지원**을 갖춘 완전한 SQLAlchemy 2.0–2.2 방언
 - **오프라인 테스트 619개**, **약 98.26% 코드 커버리지** — 데이터베이스 없이도 실행 가능
 - **동시성 스트레스 테스트** — `QueuePool` 기반 동기 스레드 + `asyncio.gather` 워크로드를 실 CUBRID에서 검증
-- **SQLAlchemy 2.2 대응 compat shim** — private API 접근을 `_compat.py`로 감쌌지만, 완전한 2.2 검증 전까지는 `<2.2`로 고정
+- **SQLAlchemy 2.2 대응 compat shim** — private API 접근을 `_compat.py`로 감쌌지만, 완전한 2.2 검증 전까지는 `<2.3`로 고정
 - **Python 3.10 -- 3.14** 전반에서 **4개 CUBRID 버전**(10.2, 11.0, 11.2, 11.4) 테스트 완료
 - CUBRID 전용 DML 구문: `ON DUPLICATE KEY UPDATE`, `MERGE`, `REPLACE INTO`
 - Alembic 마이그레이션 기본 지원
@@ -58,7 +58,7 @@ flowchart TD
 ## 요구 사항
 
 - Python 3.10+
-- SQLAlchemy 2.0 – 2.1
+- SQLAlchemy 2.0 – 2.2
 - [CUBRID-Python](https://github.com/CUBRID/cubrid-python) (C 확장) **또는** [pycubrid](https://github.com/sqlalchemy-cubrid/pycubrid) (순수 Python)
 
 ## 설치
@@ -151,7 +151,7 @@ async with AsyncSession(engine) as session:
 - **시퀀스 없음** — CUBRID는 `AUTO_INCREMENT`만 사용합니다
 - **멀티 스키마 미지원** — 데이터베이스당 단일 스키마 모델입니다
 - **DDL 자동 커밋** — 마이그레이션은 트랜잭션 처리되지 않습니다(`transactional_ddl = False`)
-- **SQLAlchemy 2.0–2.1만 지원** — 내부 API 의존성 때문에 `<2.2`로 고정되어 있습니다([자세한 내용](ARCHITECTURE.md))
+- **SQLAlchemy 2.0–2.2만 지원** — 내부 API 의존성 때문에 `<2.3`로 고정되어 있습니다([자세한 내용](ARCHITECTURE.md))
 - **Async는 pycubrid >= 1.2.0,<2.0 필요** — `cubrid+aiopycubrid://` 드라이버는 현재 이 프로젝트가 지원하는 async 가능 pycubrid 패키지 라인이 필요합니다
 
 ## 문서
@@ -176,7 +176,7 @@ async with AsyncSession(engine) as session:
 |---|---|
 | Python | 3.10, 3.11, 3.12, 3.13, 3.14 |
 | CUBRID | 10.2, 11.0, 11.2, 11.4 |
-| SQLAlchemy | 2.0–2.1 |
+| SQLAlchemy | 2.0–2.2 |
 | Alembic | >=1.7 |
 | pycubrid (sync) | >=1.2.0,<2.0 |
 | pycubrid (async) | >=1.2.0,<2.0 |
@@ -192,9 +192,9 @@ engine = create_engine("cubrid://dba:password@localhost:33000/demodb")
 
 순수 Python 드라이버(C 빌드 불필요)를 쓰려면: `create_engine("cubrid+pycubrid://dba@localhost:33000/demodb")`
 
-### sqlalchemy-cubrid는 SQLAlchemy 2.0–2.1을 지원하나요?
+### sqlalchemy-cubrid는 SQLAlchemy 2.0–2.2을 지원하나요?
 
-예. sqlalchemy-cubrid는 SQLAlchemy 2.0–2.1용으로 만들어졌으며, `Session.execute()`, 타입이 지정된 `Mapped[]` 컬럼, statement caching을 포함한 2.0 스타일 API를 지원합니다.
+예. sqlalchemy-cubrid는 SQLAlchemy 2.0–2.2용으로 만들어졌으며, `Session.execute()`, 타입이 지정된 `Mapped[]` 컬럼, statement caching을 포함한 2.0 스타일 API를 지원합니다.
 
 ### sqlalchemy-cubrid는 Alembic 마이그레이션을 지원하나요?
 

--- a/docs/README.ru.md
+++ b/docs/README.ru.md
@@ -1,6 +1,6 @@
 # sqlalchemy-cubrid
 
-**Диалект SQLAlchemy 2.0–2.1 для базы данных CUBRID** — Python ORM, рефлексия схемы, миграции Alembic и сопоставление типов для SQLAlchemy и специфичных для CUBRID типов.
+**Диалект SQLAlchemy 2.0–2.2 для базы данных CUBRID** — Python ORM, рефлексия схемы, миграции Alembic и сопоставление типов для SQLAlchemy и специфичных для CUBRID типов.
 
 [🇰🇷 한국어](README.ko.md) · [🇺🇸 English](../README.md) · [🇨🇳 中文](README.zh.md) · [🇮🇳 हिन्दी](README.hi.md) · [🇩🇪 Deutsch](README.de.md) · [🇷🇺 Русский](README.ru.md)
 
@@ -24,14 +24,14 @@
 CUBRID — это высокопроизводительная реляционная база данных с открытым исходным
 кодом, широко используемая в корейском государственном секторе и корпоративных
 приложениях. До сих пор не было активно поддерживаемого диалекта SQLAlchemy,
-который поддерживал бы современный API 2.0–2.1.
+который поддерживал бы современный API 2.0–2.2.
 
 **sqlalchemy-cubrid** закрывает этот пробел:
 
-- Полноценный диалект SQLAlchemy 2.0–2.1 с **кэшированием выражений** и **типизацией PEP 561**
+- Полноценный диалект SQLAlchemy 2.0–2.2 с **кэшированием выражений** и **типизацией PEP 561**
 - **619 офлайн-тестов** с **~98,26 % покрытия кода** — для запуска не требуется база данных
 - **Стресс-тесты конкурентности** — синхронные threaded-нагрузки `QueuePool` и `asyncio.gather` валидированы на реальном CUBRID
-- **Compat shim, готовый к SQLAlchemy 2.2** — доступ к приватным API обёрнут в `_compat.py` (пока остаётся ограничение `<2.2` до полной валидации SA 2.2)
+- **Compat shim, готовый к SQLAlchemy 2.2** — доступ к приватным API обёрнут в `_compat.py` (пока остаётся ограничение `<2.3` до полной валидации SA 2.2)
 - Протестирован на **4 версиях CUBRID** (10.2, 11.0, 11.2, 11.4) и **Python 3.10 -- 3.14**
 - CUBRID-специфичные DML-конструкции: `ON DUPLICATE KEY UPDATE`, `MERGE`, `REPLACE INTO`
 - Поддержка миграций Alembic из коробки
@@ -59,7 +59,7 @@ flowchart TD
 ## Требования
 
 - Python 3.10+
-- SQLAlchemy 2.0 – 2.1
+- SQLAlchemy 2.0 – 2.2
 - [CUBRID-Python](https://github.com/CUBRID/cubrid-python) (C-расширение) **или** [pycubrid](https://github.com/cubrid-lab/pycubrid) (чистый Python)
 
 ## Установка
@@ -152,7 +152,7 @@ async with AsyncSession(engine) as session:
 - **Нет последовательностей** — CUBRID использует только `AUTO_INCREMENT`
 - **Нет мультисхемности** — одна схема на базу данных
 - **DDL коммитится автоматически** — миграции не являются транзакционными (`transactional_ddl = False`)
-- **Только SQLAlchemy 2.0–2.1** — зафиксировано на `<2.2` из-за зависимости от внутренних API ([подробности](ARCHITECTURE.md))
+- **Только SQLAlchemy 2.0–2.2** — зафиксировано на `<2.3` из-за зависимости от внутренних API ([подробности](ARCHITECTURE.md))
 - **Async требует pycubrid >= 1.2.0,<2.0** — драйвер `cubrid+aiopycubrid://` требует async-совместимую линейку pycubrid, которую сейчас поддерживает этот проект
 
 ## Документация
@@ -177,7 +177,7 @@ async with AsyncSession(engine) as session:
 |---|---|
 | Python | 3.10, 3.11, 3.12, 3.13, 3.14 |
 | CUBRID | 10.2, 11.0, 11.2, 11.4 |
-| SQLAlchemy | 2.0–2.1 |
+| SQLAlchemy | 2.0–2.2 |
 | Alembic | >=1.7 |
 | pycubrid (sync) | >=1.2.0,<2.0 |
 | pycubrid (async) | >=1.2.0,<2.0 |
@@ -193,9 +193,9 @@ engine = create_engine("cubrid://dba:password@localhost:33000/demodb")
 
 Для драйвера на чистом Python (без C-сборки): `create_engine("cubrid+pycubrid://dba@localhost:33000/demodb")`
 
-### Поддерживает ли sqlalchemy-cubrid SQLAlchemy 2.0–2.1?
+### Поддерживает ли sqlalchemy-cubrid SQLAlchemy 2.0–2.2?
 
-Да. sqlalchemy-cubrid создан для SQLAlchemy 2.0–2.1 и поддерживает API в стиле 2.0, включая `Session.execute()`, типизированные столбцы `Mapped[]` и кэширование выражений.
+Да. sqlalchemy-cubrid создан для SQLAlchemy 2.0–2.2 и поддерживает API в стиле 2.0, включая `Session.execute()`, типизированные столбцы `Mapped[]` и кэширование выражений.
 
 ### Поддерживает ли sqlalchemy-cubrid миграции Alembic?
 

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -1,6 +1,6 @@
 # sqlalchemy-cubrid
 
-**适用于 CUBRID 数据库的 SQLAlchemy 2.0–2.1 方言** — 为 SQLAlchemy 与 CUBRID 特有类型提供 Python ORM、模式反射、Alembic 迁移和类型映射。
+**适用于 CUBRID 数据库的 SQLAlchemy 2.0–2.2 方言** — 为 SQLAlchemy 与 CUBRID 特有类型提供 Python ORM、模式反射、Alembic 迁移和类型映射。
 
 [🇰🇷 한국어](README.ko.md) · [🇺🇸 English](../README.md) · [🇨🇳 中文](README.zh.md) · [🇮🇳 हिन्दी](README.hi.md) · [🇩🇪 Deutsch](README.de.md) · [🇷🇺 Русский](README.ru.md)
 
@@ -17,19 +17,19 @@
 
 ---
 
-> **状态：Production/Stable** — 支持 CUBRID 10.2–11.4 和 SQLAlchemy 2.0–2.1 的稳定维护方言。每个 PR 均通过实时数据库集成 CI 验证。
+> **状态：Production/Stable** — 支持 CUBRID 10.2–11.4 和 SQLAlchemy 2.0–2.2 的稳定维护方言。每个 PR 均通过实时数据库集成 CI 验证。
 
 ## 为什么选择 sqlalchemy-cubrid？
 
 CUBRID 是一款高性能开源关系型数据库，在韩国公共部门和企业应用中被广泛采用。
-此前一直没有一个积极维护、支持现代 2.0–2.1 API 的 SQLAlchemy 方言。
+此前一直没有一个积极维护、支持现代 2.0–2.2 API 的 SQLAlchemy 方言。
 
 **sqlalchemy-cubrid** 填补了这一空白：
 
-- 完整的 SQLAlchemy 2.0–2.1 方言，支持**语句缓存**和 **PEP 561 类型标注**
+- 完整的 SQLAlchemy 2.0–2.2 方言，支持**语句缓存**和 **PEP 561 类型标注**
 - **619 个离线测试**，**约 98.26% 代码覆盖率** —— 无需数据库即可运行
 - **并发压力测试** —— 已在真实 CUBRID 上验证 `QueuePool` 同步线程和 `asyncio.gather` 工作负载
-- **面向 SQLAlchemy 2.2 的兼容垫片** —— 私有 API 访问被封装在 `_compat.py` 中（在完成 SA 2.2 全面验证前仍固定为 `<2.2`）
+- **面向 SQLAlchemy 2.2 的兼容垫片** —— 私有 API 访问被封装在 `_compat.py` 中（在完成 SA 2.2 全面验证前仍固定为 `<2.3`）
 - 在 **Python 3.10 -- 3.14** 上测试 **4 个 CUBRID 版本**（10.2、11.0、11.2、11.4）
 - CUBRID 特有的 DML 构造：`ON DUPLICATE KEY UPDATE`、`MERGE`、`REPLACE INTO`
 - 开箱即用的 Alembic 迁移支持
@@ -57,7 +57,7 @@ flowchart TD
 ## 环境要求
 
 - Python 3.10+
-- SQLAlchemy 2.0 – 2.1
+- SQLAlchemy 2.0 – 2.2
 - [CUBRID-Python](https://github.com/CUBRID/cubrid-python)（C 扩展）**或** [pycubrid](https://github.com/cubrid-lab/pycubrid)（纯 Python）
 
 ## 安装
@@ -150,7 +150,7 @@ async with AsyncSession(engine) as session:
 - **不支持序列** —— CUBRID 仅使用 `AUTO_INCREMENT`
 - **不支持多 schema** —— 每个数据库只有单一 schema
 - **DDL 会自动提交** —— 迁移不是事务性的（`transactional_ddl = False`）
-- **仅支持 SQLAlchemy 2.0–2.1** —— 由于内部 API 依赖，版本固定为 `<2.2`（[详情](ARCHITECTURE.md)）
+- **仅支持 SQLAlchemy 2.0–2.2** —— 由于内部 API 依赖，版本固定为 `<2.3`（[详情](ARCHITECTURE.md)）
 - **Async 需要 pycubrid >= 1.2.0,<2.0** —— `cubrid+aiopycubrid://` 驱动需要本项目当前支持的 async 能力 pycubrid 包线
 
 ## 文档
@@ -175,7 +175,7 @@ async with AsyncSession(engine) as session:
 |---|---|
 | Python | 3.10、3.11、3.12、3.13、3.14 |
 | CUBRID | 10.2、11.0、11.2、11.4 |
-| SQLAlchemy | 2.0–2.1 |
+| SQLAlchemy | 2.0–2.2 |
 | Alembic | >=1.7 |
 | pycubrid（sync） | >=1.2.0,<2.0 |
 | pycubrid（async） | >=1.2.0,<2.0 |
@@ -191,9 +191,9 @@ engine = create_engine("cubrid://dba:password@localhost:33000/demodb")
 
 对于纯 Python 驱动（无需 C 构建）：`create_engine("cubrid+pycubrid://dba@localhost:33000/demodb")`
 
-### sqlalchemy-cubrid 支持 SQLAlchemy 2.0–2.1 吗？
+### sqlalchemy-cubrid 支持 SQLAlchemy 2.0–2.2 吗？
 
-支持。sqlalchemy-cubrid 是为 SQLAlchemy 2.0–2.1 构建的，并支持 2.0 风格 API，包括 `Session.execute()`、带类型标注的 `Mapped[]` 列以及语句缓存。
+支持。sqlalchemy-cubrid 是为 SQLAlchemy 2.0–2.2 构建的，并支持 2.0 风格 API，包括 `Session.execute()`、带类型标注的 `Mapped[]` 列以及语句缓存。
 
 ### sqlalchemy-cubrid 支持 Alembic 迁移吗？
 

--- a/docs/SA_COMPAT.md
+++ b/docs/SA_COMPAT.md
@@ -4,7 +4,7 @@ This document tracks every SQLAlchemy internal or semi-private API used by
 `sqlalchemy-cubrid`, why it is used, the SQLAlchemy version range verified by
 tests, and what would break if SQLAlchemy changes the API.
 
-Verified against: SQLAlchemy `2.0.x` and `2.1.x` (project pin: `>=2.0,<2.2`).
+Verified against: SQLAlchemy `2.0.x` and `2.1.x` (project pin: `>=2.0,<2.3`).
 
 ## Internal API Inventory
 

--- a/docs/SUPPORT_MATRIX.md
+++ b/docs/SUPPORT_MATRIX.md
@@ -15,7 +15,7 @@ Compatibility and feature support for sqlalchemy-cubrid releases.
 | ≥ 2.2 | ❌ Not supported | Code uses private SA internals (see below) |
 | < 2.0 | ❌ Not supported | SA 1.x API removed |
 
-**Why `<2.2`?** The dialect accesses private SQLAlchemy APIs that may change without notice:
+**Why `<2.3`?** The dialect accesses private SQLAlchemy APIs that may change without notice:
 
 | Private API | Location | Usage |
 |---|---|---|

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,10 @@
 # sqlalchemy-cubrid
 
-SQLAlchemy 2.0–2.1 dialect for CUBRID, built for production-ready Core and ORM workloads.
+SQLAlchemy 2.0–2.2 dialect for CUBRID, built for production-ready Core and ORM workloads.
 
 ## Key features
 
-- Native SQLAlchemy 2.0–2.1 dialect support with statement caching
+- Native SQLAlchemy 2.0–2.2 dialect support with statement caching
 - CUBRID-specific DML support including `ON DUPLICATE KEY UPDATE`, `MERGE`, and `REPLACE INTO`
 - Complete type system coverage and schema reflection support
 - Built-in Alembic migration integration for CUBRID

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3386,7 +3386,7 @@ Compatibility and feature support for sqlalchemy-cubrid releases.
 | ≥ 2.2 | ❌ Not supported | Code uses private SA internals (see below) |
 | < 2.0 | ❌ Not supported | SA 1.x API removed |
 
-**Why `<2.2`?** The dialect accesses private SQLAlchemy APIs that may change without notice:
+**Why `<2.3`?** The dialect accesses private SQLAlchemy APIs that may change without notice:
 
 | Private API | Location | Usage |
 |---|---|---|

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
     "Topic :: Database :: Front-Ends",
 ]
 dependencies = [
-    "sqlalchemy>=2.0,<2.2",
+    "sqlalchemy>=2.0,<2.3",
 ]
 
 [project.optional-dependencies]

--- a/sqlalchemy_cubrid/aio_pycubrid_dialect.py
+++ b/sqlalchemy_cubrid/aio_pycubrid_dialect.py
@@ -41,6 +41,10 @@ class AsyncAdapt_pycubrid_cursor(AsyncAdapt_dbapi_cursor):
 
 class AsyncAdapt_pycubrid_connection(AsyncAdapt_dbapi_connection):
     _cursor_cls = AsyncAdapt_pycubrid_cursor
+    # SA 2.0 exposed ``await_`` on AsyncAdapt_dbapi_connection; SA 2.1 dropped
+    # it in favour of the module-level helper. Redeclare so ``self.await_(...)``
+    # works on both versions and remains patchable in tests.
+    await_ = staticmethod(await_only)
 
     @property
     def autocommit(self) -> bool:

--- a/sqlalchemy_cubrid/compiler.py
+++ b/sqlalchemy_cubrid/compiler.py
@@ -146,6 +146,22 @@ class CubridCompiler(compiler.SQLCompiler):
             return f"LIMIT {limit}"
         return None
 
+    def update_post_criteria_clause(self, update_stmt: Any, **kw: Any) -> str | None:
+        # SA 2.1 replaced the dialect-level ``update_limit_clause`` hook with
+        # ``update_post_criteria_clause``. SA 2.0 never calls this method, so
+        # the override is harmless there.
+        parts: list[str] = []
+        try:
+            base = super().update_post_criteria_clause(update_stmt, **kw)
+        except AttributeError:  # pragma: no cover — SA 2.0 base class lacks this hook
+            base = None
+        if base:
+            parts.append(base)
+        limit_text = self.update_limit_clause(update_stmt)
+        if limit_text:
+            parts.append(limit_text)
+        return " ".join(parts) if parts else None
+
     def update_tables_clause(
         self,
         update_stmt: Any,
@@ -414,7 +430,10 @@ class CubridCompiler(compiler.SQLCompiler):
                 self.process(binary.left, **kw),
                 self.process(binary.right, **kw),
             )
-        elif binary.type._type_affinity is sqltypes.Numeric:
+        elif binary.type._type_affinity is sqltypes.Numeric or (
+            # SA 2.1 split Float out of the Numeric affinity; treat both as DOUBLE.
+            binary.type._type_affinity is sqltypes.Float
+        ):
             type_expression = "ELSE CAST(JSON_EXTRACT(%s, %s) AS DOUBLE)" % (
                 self.process(binary.left, **kw),
                 self.process(binary.right, **kw),

--- a/test/test_aio_pycubrid_dialect.py
+++ b/test/test_aio_pycubrid_dialect.py
@@ -159,7 +159,16 @@ class TestAsyncAdaptPycubridConnection:
 
         conn = AsyncAdapt_pycubrid_connection(mock_dbapi, mock_async_conn)
 
-        with patch.object(conn, "await_", side_effect=lambda x: mock_cursor):
+        # SA 2.0 routes through ``self.await_``; SA 2.1 calls the module-level
+        # helper inside _aenter_cursor. Patch both so the test is version-agnostic.
+        with (
+            patch.object(conn, "await_", side_effect=lambda x: mock_cursor),
+            patch(
+                "sqlalchemy.connectors.asyncio.await_",
+                side_effect=lambda x: mock_cursor,
+                create=True,
+            ),
+        ):
             cur = conn.cursor()
 
         assert isinstance(cur, AsyncAdapt_pycubrid_cursor)


### PR DESCRIPTION
Closes #206.

## Summary

- Bumps `sqlalchemy>=2.0,<2.2` → `sqlalchemy>=2.0,<2.3` so the dialect installs on SA 2.1 (released today as `2.1.0b2`) and the upcoming SA 2.2 line.
- Adds three SA 2.1/2.2 compatibility shims fixing 8 test failures observed on SA 2.1.0b2.
- Fixes the `sqlalchemy-22-canary` CI job (was installing a non-existent `sqlalchemy>=2.2.0b1` under `continue-on-error: true` — i.e. never actually running). It now installs `--pre "sqlalchemy>=2.1.0b1,<2.3"` and gates the build.
- Updates README (EN + 5 translations), ROADMAP, CHANGELOG, ARCHITECTURE, CONNECTION, FEATURE_SUPPORT, PRD, QUICKSTART, SA_COMPAT, SUPPORT_MATRIX, index, llms-full to reflect the new 2.0–2.2 range.

## Compatibility shims

| Area | SA 2.1 change | Fix |
|---|---|---|
| UPDATE...LIMIT | `update_limit_clause` no longer called; replaced by `update_post_criteria_clause` | New `CubridCompiler.update_post_criteria_clause` override delegates to existing `update_limit_clause` |
| JSON `.as_float()` | `Float._type_affinity` split out of `Numeric` | `_render_json_extract_from_binary` now also matches `Float` affinity → `CAST(... AS DOUBLE)` |
| Async `self.await_(...)` | `AsyncAdapt_dbapi_connection` no longer provides `await_` attribute | `AsyncAdapt_pycubrid_connection.await_ = staticmethod(await_only)` redeclared at class level |

## Validation

| Check | SA 2.0.49 | SA 2.1.0b2 |
|---|---|---|
| Offline tests | 639 passed, 6 skipped | 639 passed, 6 skipped |
| Coverage | 96.96% (≥ 95% threshold) | 96.96% |
| Ruff check + format | clean | clean |
| Mypy | no new errors | no new errors |

Pre-existing mypy errors on `dialect.py:277` (CUBRIDdb stubs) are unrelated to this change.

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-opencode)