### PR TITLE
docs: fix broken pycubrid link and add async insert/PK retrieval example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -241,7 +241,7 @@ and breaking changes will only occur in major version bumps (2.0+).
 
 ### Added
 - **pycubrid dialect variant**: New `PyCubridDialect` class (`cubrid+pycubrid://` URL scheme)
-  for using the [pycubrid](https://github.com/sqlalchemy-cubrid/pycubrid) pure Python DB-API 2.0
+  for using the [pycubrid](https://github.com/cubrid-lab/pycubrid) pure Python DB-API 2.0
   driver. Subclasses `CubridDialect` — inherits all SQL compilation, type mapping, and schema
   reflection. Overrides only driver-specific methods: `import_dbapi()`, `create_connect_args()`,
   `on_connect()`, `do_ping()`.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ flowchart TD
 
 - Python 3.10+
 - SQLAlchemy 2.0 – 2.2
-- [CUBRID-Python](https://github.com/CUBRID/cubrid-python) (C-extension) **or** [pycubrid](https://github.com/sqlalchemy-cubrid/pycubrid) (pure Python)
+- [CUBRID-Python](https://github.com/CUBRID/cubrid-python) (C-extension) **or** [pycubrid](https://github.com/cubrid-lab/pycubrid) (pure Python)
 
 ## Installation
 
@@ -142,6 +142,37 @@ async with AsyncSession(engine) as session:
     print(result.scalar())
 ```
 
+#### Async insert with PK retrieval
+
+CUBRID has no `RETURNING` clause. For ORM inserts, call `await session.flush()`
+inside the transaction block to populate the auto-increment PK on the object before commit:
+
+```python
+from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
+from sqlalchemy import String
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+class Base(DeclarativeBase):
+    pass
+
+class User(Base):
+    __tablename__ = "users"
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String(100))
+
+engine = create_async_engine("cubrid+aiopycubrid://dba:password@localhost:33000/demodb")
+
+async with AsyncSession(engine) as session:
+    async with session.begin():
+        user = User(name="Alice")
+        session.add(user)
+        await session.flush()  # populates user.id without committing
+        print(f"Inserted id={user.id}")
+```
+
+For raw Core inserts where you need the auto-increment PK, run `SELECT LAST_INSERT_ID()`
+after the statement (see [Known Limitations](#known-limitations)).
+
 ## Features
 
 - Type mapping for SQLAlchemy standard and CUBRID-specific types — numeric, string, date/time, bit, LOB, collection, and JSON types
@@ -155,7 +186,7 @@ async with AsyncSession(engine) as session:
 
 ## Known Limitations
 
-- **No `RETURNING`** — `INSERT/UPDATE/DELETE ... RETURNING` not supported; use `cursor.lastrowid` or `SELECT LAST_INSERT_ID()` after the statement
+- **No `RETURNING`** — `INSERT/UPDATE/DELETE ... RETURNING` not supported; for ORM use `await session.flush()` to populate `id` on the object (see [Async Quick Start](#async)), or for Core use `cursor.lastrowid` / `SELECT LAST_INSERT_ID()` after the statement
 - **No sequences** — CUBRID uses `AUTO_INCREMENT` only
 - **No multi-schema** — single schema per database
 - **DDL auto-commits** — migrations are not transactional (`transactional_ddl = False`); use Alembic batch migrations and test rollback scenarios manually

--- a/docs/CONNECTION.md
+++ b/docs/CONNECTION.md
@@ -70,7 +70,7 @@ engine = create_engine("cubrid+pycubrid://dba@localhost:33000/testdb")
 ```
 
 > **Tip**: `pycubrid` is a pure Python implementation — it works anywhere Python runs,
-> with no native library dependencies. See [pycubrid on GitHub](https://github.com/sqlalchemy-cubrid/pycubrid).
+> with no native library dependencies. See [pycubrid on GitHub](https://github.com/cubrid-lab/pycubrid).
 ---
 
 ## Connection String Format
@@ -139,6 +139,38 @@ async with engine.connect() as conn:
     result = await conn.execute(text("SELECT 1"))
     print(result.scalar())
 ```
+
+### Async insert with PK retrieval
+
+CUBRID has no `RETURNING` clause. To obtain an auto-increment primary key after an
+async ORM insert, call `await session.flush()` inside the transaction block to populate
+the PK on the object before commit:
+
+```python
+from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
+from sqlalchemy import String
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+class Base(DeclarativeBase):
+    pass
+
+class User(Base):
+    __tablename__ = "users"
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String(100))
+
+engine = create_async_engine("cubrid+aiopycubrid://dba@localhost:33000/testdb")
+
+async with AsyncSession(engine) as session:
+    async with session.begin():
+        user = User(name="Alice")
+        session.add(user)
+        await session.flush()  # populates user.id without committing
+        print(f"Inserted id={user.id}")
+```
+
+For Core-level inserts where you need the PK, run `SELECT LAST_INSERT_ID()` after the
+statement (see README → Known Limitations).
 
 ## How the Dialect Translates URLs
 

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -59,7 +59,7 @@ flowchart TD
 
 - Python 3.10+
 - SQLAlchemy 2.0 – 2.2
-- [CUBRID-Python](https://github.com/CUBRID/cubrid-python) (C 확장) **또는** [pycubrid](https://github.com/sqlalchemy-cubrid/pycubrid) (순수 Python)
+- [CUBRID-Python](https://github.com/CUBRID/cubrid-python) (C 확장) **또는** [pycubrid](https://github.com/cubrid-lab/pycubrid) (순수 Python)
 
 ## 설치
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -284,7 +284,7 @@ engine = create_engine("cubrid+pycubrid://dba@localhost:33000/testdb")
 ```
 
 > **Tip**: `pycubrid` is a pure Python implementation — it works anywhere Python runs,
-> with no native library dependencies. See [pycubrid on GitHub](https://github.com/sqlalchemy-cubrid/pycubrid).
+> with no native library dependencies. See [pycubrid on GitHub](https://github.com/cubrid-lab/pycubrid).
 ---
 
 ## Connection String Format


### PR DESCRIPTION
## Summary

- Replace `sqlalchemy-cubrid/pycubrid` → `cubrid-lab/pycubrid` in README, docs/CONNECTION.md, docs/README.ko.md, CHANGELOG.md, docs/llms-full.txt (the `sqlalchemy-cubrid` org never existed; these links 404'd)
- Add async insert + flush + PK retrieval example to README Quick Start and docs/CONNECTION.md Async Connection section
- Cross-reference Known Limitations RETURNING bullet to the new async example

## Context

- Issue #225: `cubrid-labs` references already resolved upstream. This PR fixes the remaining `sqlalchemy-cubrid/pycubrid` wrong-org links (a more fundamental error — that org never existed, not just renamed).
- Issue #226: About description (2.0–2.1 vs 2.0–2.2) — updated via `gh repo edit` separately (admin-only metadata, not a file change).
- Issue #227: Async Quick Start lacked insert/PK retrieval pattern — fixed in this PR.

Closes #225
Closes #226
Closes #227