### PR TITLE
fix: raise CompileError for unsupported RETURNING, disable two-phase commit

### DIFF
--- a/sqlalchemy_cubrid/compiler.py
+++ b/sqlalchemy_cubrid/compiler.py
@@ -94,6 +94,33 @@ class CubridCompiler(compiler.SQLCompiler):
     def visit_lateral(self, lateral_: Any, **kw: Any) -> str:
         raise CompileError("CUBRID does not support LATERAL")
 
+    @staticmethod
+    def _check_returning(stmt: Any, operation: str) -> None:
+        """Raise CompileError if RETURNING is requested (not supported by CUBRID).
+
+        CUBRID does not support INSERT/UPDATE/DELETE ... RETURNING.
+        For auto-increment PK retrieval on INSERT, the dialect uses
+        LAST_INSERT_ID() automatically via ``result.inserted_primary_key``.
+        """
+        if getattr(stmt, "_returning", None):
+            raise CompileError(
+                f"CUBRID does not support {operation} ... RETURNING. "
+                "For auto-increment PK retrieval on INSERT, use "
+                "result.inserted_primary_key (uses LAST_INSERT_ID() automatically)."
+            )
+
+    def visit_insert(self, insert_stmt: Any, **kw: Any) -> Any:
+        self._check_returning(insert_stmt, "INSERT")
+        return super().visit_insert(insert_stmt, **kw)
+
+    def visit_update(self, update_stmt: Any, **kw: Any) -> Any:
+        self._check_returning(update_stmt, "UPDATE")
+        return super().visit_update(update_stmt, **kw)
+
+    def visit_delete(self, delete_stmt: Any, **kw: Any) -> Any:
+        self._check_returning(delete_stmt, "DELETE")
+        return super().visit_delete(delete_stmt, **kw)
+
     def for_update_clause(self, select: Any, **kw: Any) -> str:  # pyright: ignore[reportIncompatibleMethodOverride]
         """Render FOR UPDATE clause.
 

--- a/sqlalchemy_cubrid/dialect.py
+++ b/sqlalchemy_cubrid/dialect.py
@@ -258,6 +258,9 @@ class CubridDialect(default.DefaultDialect):
 
     postfetch_lastrowid = True
 
+    # Two-phase commit not supported by CUBRID
+    supports_twophase_commit = False
+
     def __init__(
         self,
         isolation_level: str | None = None,

--- a/sqlalchemy_cubrid/requirements.py
+++ b/sqlalchemy_cubrid/requirements.py
@@ -274,3 +274,10 @@ class Requirements(SuiteRequirements):
     def for_update(self) -> compound:
         """CUBRID supports SELECT ... FOR UPDATE [OF col1, col2]."""
         return _OPEN
+
+    # ----- Two-phase commit -----
+
+    @property
+    def two_phase_transactions(self) -> compound:
+        """CUBRID does not support two-phase commit (XA)."""
+        return _CLOSED

--- a/test/test_compiler.py
+++ b/test/test_compiler.py
@@ -226,6 +226,25 @@ class TestJoinCompilation:
             _compile(stmt)
 
 
+class TestReturningCompilation:
+    """Test that RETURNING raises CompileError (CUBRID does not support it)."""
+
+    def test_returning_on_insert_raises(self):
+        stmt = sa.insert(users).values(name="test").returning(users.c.id, users.c.name)
+        with pytest.raises(CompileError, match="RETURNING"):
+            _compile(stmt)
+
+    def test_returning_on_update_raises(self):
+        stmt = sa.update(users).where(users.c.id == 1).values(name="test").returning(users.c.id)
+        with pytest.raises(CompileError, match="RETURNING"):
+            _compile(stmt)
+
+    def test_returning_on_delete_raises(self):
+        stmt = sa.delete(users).where(users.c.id == 1).returning(users.c.id)
+        with pytest.raises(CompileError, match="RETURNING"):
+            _compile(stmt)
+
+
 class TestMultiTableUpdateCompilation:
     def test_multi_table_update(self):
         t1 = sa.table("t1", sa.column("id"), sa.column("val"))

--- a/test/test_dialect_offline.py
+++ b/test/test_dialect_offline.py
@@ -55,6 +55,11 @@ class TestDialectBasics:
         custom_dialect = CubridDialect(isolation_level="SERIALIZABLE")
         assert custom_dialect.isolation_level == "SERIALIZABLE"
 
+    def test_supports_twophase_commit_is_false(self):
+        """CUBRID does not support two-phase commit."""
+        dialect = CubridDialect()
+        assert dialect.supports_twophase_commit is False
+
     def test_import_dbapi_success(self):
         fake_module = types.ModuleType("CUBRIDdb")
         with patch.dict(sys.modules, {"CUBRIDdb": fake_module}):

--- a/test/test_requirements.py
+++ b/test/test_requirements.py
@@ -124,6 +124,7 @@ class TestRequirements:
             "unusual_column_name_characters",
             "implicitly_named_constraints",
             "update_nowait",
+            "two_phase_transactions",
         ],
     )
     def test_unsupported_features_are_closed(self, requirements, property_name):


### PR DESCRIPTION
## Summary

Two dialect hardening fixes:

### P1-6: RETURNING compile-time explicit error (#229)

Previously, `dialect.py:254-257` silently set `insert_returning = update_returning = delete_returning = False`. When users called `.returning()`, SQLAlchemy silently fell back — the user got no signal that RETURNING wasn't executing server-side.

**Fix**: Override `visit_insert`/`visit_update`/`visit_delete` to check `stmt._returning` before compilation. If `.returning()` is used, raise `CompileError` with an actionable message pointing to `result.inserted_primary_key` as the alternative for PK retrieval.

### P2-7: Two-phase commit explicit flag (#230)

Set `supports_twophase_commit = False` on `CubridDialect`. Previously inherited SQLAlchemy's default, causing two-phase commit to silently fail.

## Test plan

- [x] 639 offline tests pass (24 integration skipped)
- [x] 4 pre-existing Alembic failures (unrelated — `alembic.autogenerate.compare` module restructuring)
- [x] Coverage: 96.60% (threshold 95% maintained)
- [x] New tests:
  - `test_returning_on_insert_raises` — `.returning(id, name)` on INSERT → CompileError
  - `test_returning_on_update_raises` — `.returning(id)` on UPDATE → CompileError
  - `test_returning_on_delete_raises` — `.returning(id)` on DELETE → CompileError
  - `test_supports_twophase_commit_is_false` — dialect flag verified
- [x] `ruff check` + `ruff format` clean
- [x] No new mypy errors (32 pre-existing in alembic_impl.py etc.)

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-opencode)
Co-authored-by: Sisyphus <clio-agent@sisyphuslabs.ai>