### PR TITLE
release: v1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.1] - 2026-07-18
+
+### Fixed
+- **RETURNING now raises explicit `CompileError` (#229)** — the dialect previously set `insert_returning = update_returning = delete_returning = False` and silently fell back to `LAST_INSERT_ID()` for any `.returning()` call. Users had no signal that RETURNING wasn't actually executing server-side. `visit_insert`/`visit_update`/`visit_delete` now check `stmt._returning` before compilation and raise `CompileError` pointing to `result.inserted_primary_key` as the auto-increment PK retrieval path.
+- **Two-phase commit explicitly disabled (#230)** — `supports_twophase_commit = False` added to `CubridDialect`, and `two_phase_transactions` is now a `_CLOSED` requirement flag in `requirements.py` so the SA test suite properly skips two-phase tests.
+
 ## [Unreleased]
 
 ## [1.5.0] - 2026-05-23

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sqlalchemy-cubrid"
-version = "1.5.0"
+version = "1.5.1"
 description = "CUBRID dialect for SQLAlchemy"
 readme = "README.md"
 license = "MIT"

--- a/sqlalchemy_cubrid/__init__.py
+++ b/sqlalchemy_cubrid/__init__.py
@@ -52,7 +52,7 @@ from sqlalchemy.sql.sqltypes import (
     TIMESTAMP,
 )
 
-__version__ = "1.5.0"
+__version__ = "1.5.1"
 
 __all__ = (
     "insert",


### PR DESCRIPTION
## v1.5.1 — Patch Release

### Fixed
- **P1**: RETURNING now raises explicit `CompileError` (#229)
- **P2**: Two-phase commit explicitly disabled via flag + requirement (#230)

See [CHANGELOG.md](https://github.com/cubrid-lab/sqlalchemy-cubrid/blob/release/v1.5.1/CHANGELOG.md) for full details.

Tag `v1.5.1` already pushed. PyPI publish workflow will trigger on merge.