### PR TITLE
fix(_compat): insulate bind_with_type against SA private API changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,7 @@ jobs:
 
   sqlalchemy-22-canary:
     runs-on: ubuntu-latest
+    continue-on-error: true  # Canary: warn, don't gate. SA pre-releases may break.
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -109,7 +110,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
-          pip install --pre "sqlalchemy>=2.1.0b1,<2.3"
+          pip install --pre "sqlalchemy>=2.2.0b1,<2.3"
       - name: Run offline tests (canary)
         run: |
           python -m pytest \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`bind_with_type` private API insulation (#231)** — `bind_with_type()` in `_compat.py` called `element._clone()` without a guard. If SQLAlchemy renames or removes `_clone()` in a future release (e.g. 2.2+), the dialect would crash with `AttributeError`. Added `try/except AttributeError` fallback that constructs a fresh `BindParameter` with the same key, value, type, and unique flag. This path only fires if SA changes the private API; the existing `_clone()` path remains the primary code path for SA 2.0–2.1.
+
+### CI
+- **SA 2.2 canary bumped (#231)** — the `sqlalchemy-22-canary` CI job now installs `sqlalchemy>=2.2.0b1` (was `>=2.1.0b1`, which is no longer a pre-release). Added `continue-on-error: true` so canary failures warn but don't gate PRs — pre-release breakage is expected and shouldn't block development.
 ## [1.5.0] - 2026-05-23
 
 ### Added

--- a/sqlalchemy_cubrid/_compat.py
+++ b/sqlalchemy_cubrid/_compat.py
@@ -31,8 +31,18 @@ def is_literal_value(value: Any) -> bool:
 
 
 def bind_with_type(element: elements.BindParameter[Any], type_: Any) -> elements.BindParameter[Any]:
-    """Create a copy of *element* with *type_* overridden, preserving all internal state."""
-    cloned = element._clone()
+    """Create a copy of *element* with *type_* overridden, preserving all internal state.
+
+    Uses ``_clone()`` when available (SA 2.0–2.1); falls back to constructing
+    a fresh ``BindParameter`` if the private ``_clone()`` API is removed or
+    renamed in a future SA release (e.g. 2.2+).
+    """
+    try:
+        cloned = element._clone()
+    except AttributeError:
+        # Fallback: construct a new BindParameter with same key/value/type.
+        # This path only fires if SA removes _clone(); covered by canary CI.
+        return elements.BindParameter(element.key, element.value, type_=type_, unique=True)  # type: ignore[call-arg]
     cloned.type = type_
     return cloned
 

--- a/test/test_compiler.py
+++ b/test/test_compiler.py
@@ -310,6 +310,21 @@ class TestCompatHelpers:
         assert typed_element.unique == element.unique
         assert isinstance(typed_element.type, users.c.name.type.__class__)
 
+    def test_bind_with_type_fallback_when_clone_missing(self):
+        """Verify graceful degradation if SA removes _clone() in a future release."""
+        from unittest.mock import PropertyMock, patch
+
+        element = sa.bindparam("name", "value", unique=True)
+        # Simulate _clone being unavailable (hypothetical SA 2.2+ rename)
+        with patch.object(type(element), "_clone", new_callable=PropertyMock) as mock_clone:
+            mock_clone.side_effect = AttributeError("_clone removed")
+            typed_element = bind_with_type(element, users.c.name.type)
+
+        assert typed_element is not element
+        assert typed_element.value == "value"
+        assert typed_element.unique is True
+        assert isinstance(typed_element.type, users.c.name.type.__class__)
+
 
 class TestFunctionCompilation:
     """Test function compilation (SYSDATE, UTC_TIMESTAMP)."""


### PR DESCRIPTION
## Summary

Closes #231. Insulates the only unguarded private API access in `_compat.py` against future SQLAlchemy changes, and updates the SA 2.2 canary CI job.

## Changes

### `sqlalchemy_cubrid/_compat.py`
- Added `try/except AttributeError` guard around `element._clone()` in `bind_with_type()`
- Fallback constructs a fresh `BindParameter(element.key, element.value, type_=type_, unique=True)`
- Only fires if SA removes/renames `_clone()` in a future release

### `.github/workflows/ci.yml`
- Bumped `sqlalchemy-22-canary` job from `>=2.1.0b1` to `>=2.2.0b1` (2.1 is GA, no longer a pre-release)
- Added `continue-on-error: true` so canary failures warn but don't gate PRs

### `test/test_compiler.py`
- New test `test_bind_with_type_fallback_when_clone_missing` simulates `_clone()` being unavailable and verifies the fallback path produces a valid `BindParameter`

## Oracle Design Review

Approved (session \`ses_08afbfaadffeNsM1XNJdxeXxk2\`):

> The current `_compat.py` is already well-insulated — it uses `getattr` with defaults for 4/6 functions. The real risk is `_clone()` in `bind_with_type`. Add `try/except` guard. Bump canary from `>=2.1.0b1` to `>=2.2.0b1`. Keep `<2.3` pin until SA 2.2 GA.

## Pin Strategy

- **Current**: `sqlalchemy>=2.0,<2.3` (unchanged)
- **After SA 2.2 GA + canary green for 2+ weeks**: bump to `<2.4`
- **Never** remove the upper bound entirely — SA has broken dialect internals across majors

## Test Coverage

- 644 tests pass (4 pre-existing alembic failures unrelated to this change)
- All existing `bind_with_type` tests pass unchanged
- New fallback test verifies graceful degradation

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-opencode)
Co-authored-by: Sisyphus <clio-agent@sisyphuslabs.ai>