### PR TITLE
fix: quote mermaid labels to fix GitHub rendering

### DIFF
--- a/docs/CONNECTION.md
+++ b/docs/CONNECTION.md
@@ -454,9 +454,9 @@ flowchart TD
     check -->|cubrid or cubrid+cubrid| cext[Build CUBRID native DSN]
     check -->|cubrid+pycubrid| pykw[Build pycubrid kwargs]
     check -->|cubrid+aiopycubrid| aio[Build pycubrid.aio kwargs]
-    cext --> connect1[CUBRIDdb.connect(url, user, password)]
-    pykw --> connect2[pycubrid.connect(host, port, database, user, password)]
-    aio --> connect3[pycubrid.aio.connect(...)]
+    cext --> connect1["CUBRIDdb.connect(url, user, password)"]
+    pykw --> connect2["pycubrid.connect(host, port, database, user, password)"]
+    aio --> connect3["pycubrid.aio.connect(...)"]
     connect1 --> session[Dialect on_connect sets autocommit=False]
     connect2 --> session
     connect3 --> session


### PR DESCRIPTION
## Summary

3 mermaid node labels in `docs/CONNECTION.md` contained unquoted parentheses that GitHub's mermaid parser interprets as node-shape delimiters, causing diagrams to fail rendering.

## Root Cause

```mermaid
# Broken — parser sees () as shape change
cext --> connect1[CUBRIDdb.connect(url, user, password)]

# Fixed — double quotes escape the entire label
cext --> connect1["CUBRIDdb.connect(url, user, password)"]
```

## Verification

Mermaid scanner reports 0 issues (was 3).

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-opencode)
Co-authored-by: Sisyphus <clio-agent@sisyphuslabs.ai>