### PR TITLE
ci: add doc-lint job using reusable workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,14 @@ jobs:
           fi
           echo "CHANGELOG check passed"
 
+
+  doc-lint:
+    name: Documentation lint
+    uses: cubrid-lab/.github/.github/workflows/doc-lint.yml@main
+    with:
+      exclude: "node_modules/,vendor/"
+      fail-on-issue: false  # advisory mode during initial rollout
+
   # ──────────────────────────────────────────
   # Job 1: Lint (fast, no DB needed)
   # ──────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds a documentation lint job to CI that calls the reusable workflow at `cubrid-lab/.github/.github/workflows/doc-lint.yml@main`.

## Checks
- **markdownlint-cli2** — markdown style
- **lychee** — internal link checker
- **scan_mermaid.py** — mermaid syntax validation

Advisory mode initially (`fail-on-issue: false`).

## Related
- Reusable workflow: cubrid-lab/.github#17 (merged)
- Mermaid fixes: #238 (merged)

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-opencode)
Co-authored-by: Sisyphus <clio-agent@sisyphuslabs.ai>