### PR TITLE
fix: resolve 5 code review issues (#242-246)

### DIFF
--- a/sqlalchemy_cubrid/base.py
+++ b/sqlalchemy_cubrid/base.py
@@ -391,10 +391,6 @@ class CubridIdentifierPreparer(compiler.IdentifierPreparer):
     ) -> None:
         super().__init__(dialect, initial_quote, final_quote, escape_quote, omit_schema)
 
-    def _quote_free_identifiers(self, *ids: str | None) -> tuple[str, ...]:
-        """Unilaterally identifier-quote any number of strings."""
-        return tuple(self.quote_identifier(i) for i in ids if i is not None)
-
 
 class CubridExecutionContext(default.DefaultExecutionContext):
     """Execution context for CUBRID connections."""

--- a/sqlalchemy_cubrid/compiler.py
+++ b/sqlalchemy_cubrid/compiler.py
@@ -62,6 +62,9 @@ class CubridCompiler(compiler.SQLCompiler):
         return f"CAST({self.process(cast.clause)} AS {type_})"
 
     def render_literal_value(self, value: Any, type_: Any) -> str:
+        # SQLAlchemy's base render_literal_value only escapes single quotes.
+        # CUBRID uses backslash escaping (like MySQL), so we must also double
+        # backslashes to prevent them from being interpreted as escape sequences.
         rendered = str(super().render_literal_value(value, type_))
         rendered = rendered.replace("\\", "\\\\")
         return rendered
@@ -428,7 +431,9 @@ class CubridCompiler(compiler.SQLCompiler):
             return text.replace("INSERT INTO", "REPLACE INTO", 1)
         if text.startswith("INSERT"):
             return "REPLACE" + text[len("INSERT") :]
-        return text
+        raise NotImplementedError(
+            f"Could not convert INSERT to REPLACE: unexpected SQL format: {text!r}"
+        )
 
     def _render_json_extract_from_binary(
         self, binary: elements.BinaryExpression[Any], operator: Any, **kw: Any

--- a/sqlalchemy_cubrid/dialect.py
+++ b/sqlalchemy_cubrid/dialect.py
@@ -627,7 +627,11 @@ class CubridDialect(default.DefaultDialect):
         except Exception:
             # Fallback: if the catalog query fails, both sets stay empty so
             # no indexes will be wrongly excluded.
-            log.debug("Batch index-flag query failed for table %s, falling back", table_name)
+            log.debug(
+                "Batch index-flag query failed for table %s, falling back",
+                table_name,
+                exc_info=True,
+            )
 
         quoted = self.identifier_preparer.quote_identifier(table_name)
         result = connection.execute(text(f"SHOW INDEXES IN {quoted}"))
@@ -1038,8 +1042,11 @@ class CubridDialect(default.DefaultDialect):
         Python driver exposes a ``ping()`` method on the connection
         that delegates to the C-level CCI ping.
         """
-        dbapi_connection.ping()
-        return True
+        try:
+            dbapi_connection.ping()
+            return True
+        except Exception:
+            return False
 
 
 dialect = CubridDialect

--- a/sqlalchemy_cubrid/dml.py
+++ b/sqlalchemy_cubrid/dml.py
@@ -178,6 +178,7 @@ def merge(target: _DMLTableArgument) -> Merge:
 class Merge(Executable, ClauseElement, Generative):
     __visit_name__ = "merge"
     stringify_dialect = "cubrid"
+    inherit_cache = True
 
     _target: _DMLTableArgument
     _using_source: Optional[Any]

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -61,13 +61,6 @@ class TestIdentifierPreparer:
         assert preparer.escape_quote == '"'
         assert preparer.omit_schema is False
 
-    def test_quote_free_identifiers_skips_none(self):
-        preparer = CubridIdentifierPreparer(CubridDialect())
-
-        quoted = preparer._quote_free_identifiers("users", None, "order")
-
-        assert quoted == ('"users"', '"order"')
-
 
 class TestExecutionContext:
     def test_should_autocommit_text(self):

--- a/test/test_dialect_offline.py
+++ b/test/test_dialect_offline.py
@@ -1001,14 +1001,14 @@ class TestDoPing:
         assert result is True
         dbapi_conn.ping.assert_called_once()
 
-    def test_ping_propagates_exception(self):
-        """do_ping() lets exceptions propagate (SA catches them)."""
+    def test_ping_returns_false_on_exception(self):
+        """do_ping() returns False on failure instead of propagating."""
         dialect = CubridDialect()
         dbapi_conn = MagicMock()
         dbapi_conn.ping.side_effect = RuntimeError("connection lost")
 
-        with pytest.raises(RuntimeError, match="connection lost"):
-            dialect.do_ping(dbapi_conn)
+        result = dialect.do_ping(dbapi_conn)
+        assert result is False
 
 
 class TestPostfetchLastRowId:

--- a/test/test_reflection_golden.py
+++ b/test/test_reflection_golden.py
@@ -344,9 +344,7 @@ def mock_empty_table() -> _MockEmptyTable:
     return _MockEmptyTable()
 
 
-def test_get_indexes_empty_table(
-    dialect: CubridDialect, mock_empty_table: _MockEmptyTable
-) -> None:
+def test_get_indexes_empty_table(dialect: CubridDialect, mock_empty_table: _MockEmptyTable) -> None:
     """A table with no indexes should return an empty list, not crash."""
     indexes = dialect.get_indexes(mock_empty_table, "heap_table")
     assert indexes == []
@@ -376,9 +374,7 @@ def test_get_unique_constraints_empty_table(
     assert ucs == []
 
 
-def test_get_columns_no_comment(
-    dialect: CubridDialect, mock_empty_table: _MockEmptyTable
-) -> None:
+def test_get_columns_no_comment(dialect: CubridDialect, mock_empty_table: _MockEmptyTable) -> None:
     """A column with no comment should reflect comment as None."""
     columns = [dict(c) for c in dialect.get_columns(mock_empty_table, "heap_table")]
     assert len(columns) == 1
@@ -386,9 +382,7 @@ def test_get_columns_no_comment(
     assert columns[0]["comment"] is None
 
 
-def test_get_table_comment_empty(
-    dialect: CubridDialect, mock_empty_table: _MockEmptyTable
-) -> None:
+def test_get_table_comment_empty(dialect: CubridDialect, mock_empty_table: _MockEmptyTable) -> None:
     """A table with no comment should return {"text": None}."""
     comment = dialect.get_table_comment(mock_empty_table, "heap_table")
     assert comment == {"text": None}
@@ -434,9 +428,7 @@ def mock_null_flags() -> _MockNullFlags:
     return _MockNullFlags()
 
 
-def test_get_indexes_null_flags(
-    dialect: CubridDialect, mock_null_flags: _MockNullFlags
-) -> None:
+def test_get_indexes_null_flags(dialect: CubridDialect, mock_null_flags: _MockNullFlags) -> None:
     """Document behavior when _db_index returns NULL for boolean flags.
 
     In CUBRID's ``_db_index`` system view, ``is_primary_key`` and


### PR DESCRIPTION
## Summary

| Issue | Severity | Fix |
|-------|----------|-----|
| #242 | P1 | Document render_literal_value backslash escaping (code correct, added comment) |
| #243 | P1 | visit_replace fallback now raises NotImplementedError instead of silent INSERT |
| #244 | P2 | Wrap do_ping in try/except, returns False on failure |
| #245 | P2 | Add inherit_cache to Merge; remove dead _quote_free_identifiers |
| #246 | P2 | Add exc_info=True to remaining broad except block |

## Test Plan

- 624 tests passed, 59 skipped (2 pre-existing alembic failures excluded)