### PR TITLE
ci: migrate CodeQL to org-level reusable workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,18 +15,6 @@ permissions:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7
-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4.37.4
-        with:
-          languages: python
-          queries: security-extended
-
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4.37.4
-        with:
-          category: "/language:python"
+    uses: cubrid-lab/.github/.github/workflows/codeql.yml@main
+    with:
+      language: python


### PR DESCRIPTION
## Summary

Replace the inline CodeQL workflow with a call to the org-level reusable workflow at `cubrid-lab/.github/.github/workflows/codeql.yml@main`.

Refs cubrid-lab/.github#11