### PR TITLE
fix: move upstream-canary to separate workflow file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,18 +250,3 @@ jobs:
           needs.packaging-smoke-test.result == 'failure' ||
           needs.integration-tests.result == 'failure'
         run: exit 1
-
-  upstream-canary:
-    name: Test against pycubrid@main
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    schedule:
-      - cron: "0 6 * * 1"
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-      - run: pip install -e ".[dev]"
-      - run: pip install --force-reinstall "git+https://github.com/cubrid-lab/pycubrid.git@main"
-      - run: pytest test/ --ignore=test/test_integration.py --ignore=test/test_aio_integration.py -q

--- a/.github/workflows/upstream-canary.yml
+++ b/.github/workflows/upstream-canary.yml
@@ -1,0 +1,20 @@
+name: Upstream Canary
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+jobs:
+  upstream-canary:
+    name: Test against pycubrid@main
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install -e ".[dev]"
+      - run: pip install --force-reinstall "git+https://github.com/cubrid-lab/pycubrid.git@main"
+      - run: pytest test/ --ignore=test/test_integration.py --ignore=test/test_aio_integration.py -q


### PR DESCRIPTION
## Summary

Same fix as cubrid-mcp-server #81: the `schedule:` trigger was at the job level, but GitHub Actions requires `on: schedule:` at the workflow level. The canary never ran on schedule.

### Changes

- Remove `upstream-canary` job from `ci.yml`
- Create `.github/workflows/upstream-canary.yml` with `on: schedule:` + `workflow_dispatch:`