### PR TITLE
fix: remove orphaned `import re` breaking lint on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Lint job red on `main` (#268)** — `#257` removed the only use of `re` in `test/test_packaging.py` but left `import re` behind, so `ruff check sqlalchemy_cubrid/ test/` failed with `F401` and took `matrix-result` down with it. Removed the orphaned import.
+
 ## [1.6.0] - 2026-07-18
 
 ### Fixed

--- a/test/test_packaging.py
+++ b/test/test_packaging.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 import importlib
 import importlib.metadata
 import importlib.resources
-import re
 from pathlib import Path
 from typing import cast
 


### PR DESCRIPTION
Gets the `lint` job on `main` green again.

## What was wrong

```
F401 [*] `re` imported but unused
  --> test/test_packaging.py:16:8
Found 1 error.
```

`ab9c0e5` ("chore: migrate to dynamic version source (#257)") removed the only use of `re` in that file:

```python
-        match = re.search(r'^version = "([^"]+)"', _read_pyproject(), re.MULTILINE)
```

and left `import re` behind. Nothing else in the file references `re`, so `ruff check sqlalchemy_cubrid/ test/` — the exact command the `lint` job runs — fails under the pinned `ruff==0.15.21`, which also fails `matrix-result`.

## What this PR does

Deletes the orphaned import. One line, no behavior change.

## Verification

```
ruff check sqlalchemy_cubrid/ test/          All checks passed!
ruff format --check sqlalchemy_cubrid/ test/ 34 files already formatted
pytest test/ -m "not integration"            656 passed, 59 skipped
```

## This does not make `main` fully green

Two unrelated failures remain and are worth separate issues:

1. **`sqlalchemy-22-canary`** fails at "Install dependencies with SQLAlchemy pre-release".
2. **Ruff bump #267** (`0.15.21 → 0.16.2`) fails lint with **151 errors** in untouched code. `pyproject.toml` never declares `[tool.ruff.lint] select`, so `ruff check` inherits ruff's implicit defaults — and ruff expanded that default set in 0.16 (59 → 413 rules against this repo's own config). Same root cause as cubrid-mcp-server [#88](https://github.com/cubrid-lab/cubrid-mcp-server/issues/88) / [#90](https://github.com/cubrid-lab/cubrid-mcp-server/pull/90); pycubrid [#245](https://github.com/cubrid-lab/pycubrid/pull/245) is blocked by it as well. Follow-up PR coming.

Closes #268
