### PR TITLE
build: pin ruff's lint rule selection so version bumps stop breaking CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Ruff lint rule selection now declared explicitly (#271)** — `pyproject.toml` configured ruff but never set `[tool.ruff.lint] select`, so `ruff check` inherited ruff's implicit defaults. Ruff expanded that default set in 0.16 (59 → 413 rules against this repo's config), which is why #267 (`0.15.21 → 0.16.2`) failed lint with 151 errors in untouched code. Pinning the ruff *version* in #252 stopped unpinned installs from drifting, but could not survive the bump itself — the rule set is now pinned too, via `select = ["E4", "E7", "E9", "F"]`, which is exactly what ruff selected by default through 0.15.x (same 59 rules under both versions).
+
 ### Fixed
 - **Lint job red on `main` (#268)** — `#257` removed the only use of `re` in `test/test_packaging.py` but left `import re` behind, so `ruff check sqlalchemy_cubrid/ test/` failed with `F401` and took `matrix-result` down with it. Removed the orphaned import.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,14 @@ version = {attr = "sqlalchemy_cubrid.__version__"}
 line-length = 100
 target-version = "py310"
 
+[tool.ruff.lint]
+# Pin the rule set explicitly instead of inheriting ruff's implicit defaults.
+# Ruff expanded its default selection in 0.16 (59 -> 413 rules against this
+# config), which turns every routine ruff bump into a CI-breaking change
+# unrelated to our own code. These four groups are exactly what ruff selected
+# by default through 0.15.x.
+select = ["E4", "E7", "E9", "F"]
+
 [tool.ruff.lint.isort]
 known-first-party = ["sqlalchemy_cubrid"]
 


### PR DESCRIPTION
Unblocks #267 and every future ruff bump.

## What was wrong

`pyproject.toml` configured ruff but never declared a rule selection, so `ruff check` ran whatever ruff picks by default. Ruff changed that default in 0.16:

```
$ ruff@0.15.21 check --show-settings pyproject.toml   ->  59 rules
$ ruff@0.16.2  check --show-settings pyproject.toml   -> 413 rules  ->  Found 151 errors
```

That is why #267 (`ruff 0.15.21 → 0.16.2`) fails `lint` — and with it `matrix-result` — on 151 errors in code the PR never touches.

## Why the version pin in #252 was not enough

#252 stopped the lint job installing ruff unpinned, so a fresh `pip install ruff` could no longer drift to whatever shipped that morning. That was the right fix for that problem.

But a version pin only holds until the pin itself moves. The moment dependabot proposes `0.15.21 → 0.16.2`, the implicit default rule set moves with it and the build breaks again — which is exactly what #267 is. Pinning the *rule set* is the missing half.

## What this PR does

```toml
[tool.ruff.lint]
select = ["E4", "E7", "E9", "F"]
```

`E4`/`E7`/`E9`/`F` are exactly what ruff selected by default through 0.15.x — verified as the same 59 rules under both 0.15.21 and 0.16.2. No lint findings change today; the difference is that the next bump can no longer move the goalposts.

## Verification

Using `sqlalchemy_cubrid/ test/`, the exact paths the `lint` job checks:

```
                      before this PR      after this PR
ruff@0.15.21 check    1 error             1 error
ruff@0.16.2  check    151 errors          1 error
ruff@0.16.2  format   35 files formatted  35 files formatted
```

**The one remaining error is not this PR's.** It is the orphaned `import re` in `test/test_packaging.py` left by #257 — tracked as #268 and fixed by #270, which is a one-line change. Merging #270 first takes lint to zero under both ruff versions; this branch can then be rebased and will be fully green.

So: #270 → this PR → #267.

## Org-wide

Same root cause in the sibling repos — cubrid-mcp-server was fixed in [#90](https://github.com/cubrid-lab/cubrid-mcp-server/pull/90), pycubrid in [#248](https://github.com/cubrid-lab/pycubrid/pull/248); cubrid-cookbook-python (260 errors, `main` already red, no ruff pin at all) still needs it.

Closes #271
